### PR TITLE
capture google api status and error message

### DIFF
--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -29,6 +29,12 @@
             if (err) {
                 throw err;
             } else {
+                // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
+                // error_message may or may not be present
+                if (result.status !== 'OK') {
+                    return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')));
+                }
+
                 var results = [];
 
                 for(var i = 0; i < result.results.length; i++) {
@@ -108,6 +114,12 @@
             if (err) {
                 throw err;
             } else {
+                // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
+                // error_message may or may not be present
+                if (result.status !== 'OK') {
+                    return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')));
+                }
+
                 var results = [];
 
                 if(result.results.length > 0) {

--- a/test/geocoder/googlegeocoder.js
+++ b/test/geocoder/googlegeocoder.js
@@ -8,7 +8,9 @@
     var HttpAdapter = require('../../lib/httpadapter/httpadapter.js');
 
     var mockedHttpAdapter = {
-        get: function() {}
+        get: function() {
+          return {}
+        }
     };
 
     describe('GoogleGeocoder', function() {
@@ -65,7 +67,7 @@
 
             it('Should return geocoded adress', function(done) {
                 var mock = sinon.mock(mockedHttpAdapter);
-                mock.expects('get').once().callsArgWith(2, false, { results: [{
+                mock.expects('get').once().callsArgWith(2, false, { status: "OK", results: [{
                         geometry: {location : {
                             lat: 37.386,
                             lng: -122.0838
@@ -107,6 +109,32 @@
 
             });
 
+            it('Should handle a not "OK" status', function(done) {
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, { status: "OVER_QUERY_LIMIT", error_message: "You have exceeded your rate-limit for this API.", results: [] });
+
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
+
+                googleAdapter.geocode('1 champs élysées Paris', function(err, results) {
+                    err.message.should.to.equal("Status is OVER_QUERY_LIMIT. You have exceeded your rate-limit for this API.");
+                    mock.verify();
+                    done();
+                });
+            });
+
+            it('Should handle a not "OK" status and no error_message', function(done) {
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, { status: "INVALID_REQUEST", results: [] });
+
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
+
+                googleAdapter.geocode('1 champs élysées Paris', function(err, results) {
+                    err.message.should.to.equal("Status is INVALID_REQUEST.");
+                    mock.verify();
+                    done();
+                });
+            });
+
         });
 
         describe('#reverse' , function() {
@@ -125,7 +153,7 @@
 
             it('Should return geocoded adress', function(done) {
                 var mock = sinon.mock(mockedHttpAdapter);
-                mock.expects('get').once().callsArgWith(2, false, { results: [{
+                mock.expects('get').once().callsArgWith(2, false, { status: "OK", results: [{
                         geometry: {location : {
                             lat: 40.714232,
                             lng: -73.9612889
@@ -162,6 +190,32 @@
                         });
                         mock.verify();
                         done();
+                });
+            });
+
+            it('Should handle a not "OK" status', function(done) {
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, { status: "OVER_QUERY_LIMIT", error_message: "You have exceeded your rate-limit for this API.", results: [] });
+
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
+
+                googleAdapter.reverse(40.714232,-73.9612889, function(err, results) {
+                    err.message.should.to.equal("Status is OVER_QUERY_LIMIT. You have exceeded your rate-limit for this API.");
+                    mock.verify();
+                    done();
+                });
+            });
+
+            it('Should handle a not "OK" status and no error_message', function(done) {
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, { status: "INVALID_REQUEST", results: [] });
+
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
+
+                googleAdapter.reverse(40.714232,-73.9612889, function(err, results) {
+                    err.message.should.to.equal("Status is INVALID_REQUEST.");
+                    mock.verify();
+                    done();
                 });
             });
         });


### PR DESCRIPTION
Currently the google adapter hides the error status and messages behind just an empty result set. Instead, I'm using the error argument of the callback to signal to the user that the api request did not work out as expected.
