### PR TITLE
added 'host' option for alternative DSTK endpoint

### DIFF
--- a/lib/geocoder/datasciencetoolkitgeocoder.js
+++ b/lib/geocoder/datasciencetoolkitgeocoder.js
@@ -6,21 +6,41 @@
     /**
      * Constructor
      */
-    var DataScienceToolkitGeocoder = function(httpAdapter) {
+    var DataScienceToolkitGeocoder = function(httpAdapter,options) {
 
         if (!httpAdapter || httpAdapter == 'undefinded') {
 
             throw new Error('DataScienceToolkitGeocoder need an httpAdapter');
         }
+        if (!options || options == 'undefinded') {
+            options = {};
+        }
 
+        if (!options.host || options.host == 'undefinded') {
+            options.host = null;
+        }
+
+        this.options = options;
         this.httpAdapter = httpAdapter;
     };
 
-    // Ipv4 WS endpoint
-    DataScienceToolkitGeocoder.prototype._ipv4Endpoint = 'http://www.datasciencetoolkit.org/ip2coordinates/';
-
-    // Street to coordinate endpoint
-    DataScienceToolkitGeocoder.prototype._street2coordinatesEndpoint = 'http://www.datasciencetoolkit.org/street2coordinates/';
+    /** 
+    * Build DSTK endpoint, allows for local DSTK installs
+    * @param <string>   value    Value to geocode (Adress or ipV4)
+    */
+    DataScienceToolkitGeocoder.prototype._endpoint = function(value) {
+       var ep = { };
+       var host = "www.datasciencetoolkit.org";
+       
+       if(this.options.host) {
+            host =  this.options.host;
+        } 
+        
+        ep.ipv4Endpoint = 'http://'+host+'/ip2coordinates/';
+        ep.street2coordinatesEndpoint = 'http://'+host+'/street2coordinates/';
+        
+        return net.isIPv4(value) ? ep.ipv4Endpoint : ep.street2coordinatesEndpoint;
+    }
 
     /**
     * Geocode
@@ -29,14 +49,12 @@
     */
     DataScienceToolkitGeocoder.prototype.geocode = function(value, callback) {
 
-        this._endpoint = net.isIPv4(value) ? this._ipv4Endpoint : this._street2coordinatesEndpoint;
-
-        this.httpAdapter.get(this._endpoint + value , { }, function(err, result) {
+        var ep = this._endpoint(value);
+        this.httpAdapter.get(ep + value , { }, function(err, result) {
             if (err) {
                 return callback(err);
             } else {
                 result = result[value];
-
                 if (!result) {
                     return callback(new Error('Could not geocode "' + value + '".'));
                 }
@@ -60,6 +78,7 @@
         });
 
     };
+
 
     /**
     * Reverse geocoding Unsuported

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -47,7 +47,7 @@
 			if (geocoderName === 'datasciencetoolkit') {
 				var DataScienceToolkitGeocoder = new require('./geocoder/datasciencetoolkitgeocoder.js');
 
-				return new DataScienceToolkitGeocoder(adapter);
+				return new DataScienceToolkitGeocoder(adapter,{host: extra.host});
 			}
 			if (geocoderName === 'openstreetmap') {
 				var OpenStreetMapGeocoder = new require('./geocoder/openstreetmapgeocoder.js');


### PR DESCRIPTION
Allows alternate host for data science toolkit. Very useful for high volume geocoding with local [DSTK VM](http://www.datasciencetoolkit.org/developerdocs#setup).

Example:

```
var geocoderProvider = 'datasciencetoolkit';
var httpAdapter = 'http';
// optionnal
var extra = { host: '10.0.1.10' };

var geocoder = require('node-geocoder').getGeocoder(geocoderProvider, httpAdapter, extra);

geocoder.geocode('101 hyde st, san francisco, ca', function(err, res) {
    console.log(res);
});

geocoder.geocode('8.8.8.8', function(err, res) {
    console.log(res);
});
```
