### PR TITLE
Calculate Google API signature using actual parameters passed to API

### DIFF
--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -102,12 +102,10 @@ GoogleGeocoder.prototype._prepareQueryString = function() {
 GoogleGeocoder.prototype._signedRequest = function(endpoint, params) {
     if (this.options.clientId) {
         var request = url.parse(endpoint);
-        request.query = params;
-        request = url.parse(url.format(request));
-        request.path = '/maps/api/geocode/json?address=blah&sensor=false&client=foo';
+        var fullRequestPath = request.path + url.format({ query: params });
         var decodedKey = new Buffer(this.options.apiKey.replace('-', '+').replace('_', '/'), 'base64').toString('binary');
         var hmac = crypto.createHmac('sha1', decodedKey);
-        hmac.update(request.path);
+        hmac.update(fullRequestPath);
         var signature = hmac.digest('base64');
 
         signature = signature.replace('+', '-').replace('/', '_');


### PR DESCRIPTION
I noticed that your calculations for the Google API signature were using dummy data instead of the actual data passed to the API. This was causing the signature to fail. Please consider merging in this fix so Google Maps API for Business users can use authenticated requests. 
