### PR TITLE
add ending bracket to Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ geocoder.geocode('29 champs elysée paris')
 }]
 
 ## Advenced usage (only google provider)
-geocoder.geocode({address: '29 champs elysée', country: 'France', zipcode: '75008', function(err, res) {
+geocoder.geocode({address: '29 champs elysée', country: 'France', zipcode: '75008'}, function(err, res) {
     console.log(res);
 });
 


### PR DESCRIPTION
Hey, 

Great work on node-geocoder!

While using the example in the Readme, I ran into a missing right bracket. I've submitted this pull request to fix the Readme.

Thanks
