### PR TITLE
Remove extra dependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+.jshintrc
+.travis.yml

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
   "dependencies": {
     "q": "~1.0.1",
     "commander": "~2.2.0",
-    "chai": "~1.8.1",
-    "mocha": "~1.14.0",
-    "sinon": "~1.7.3"
   },
   "devDependencies": {
     "chai": "~1.8",


### PR DESCRIPTION
It looks like the test deps made their way into the regular dependencies as well, taking these out will slim down the package considerably. And while slimming, you can add a `.npmignore` to take the tests and related files out of the published package on npm to make it even smaller :grinning: 

Also, +100 for using Fornino as the example!
