### PR TITLE
Gulp task runner added for linting.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,9 @@
+var jshint = require('gulp-jshint');
+var gulp   = require('gulp');
+
+gulp.task('lint', function() {
+  return gulp.src(['**/*.js',
+  '!./node_modules/**'])
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'));
+});

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "chai": "~1.8",
+    "gulp": "^3.8.8",
+    "gulp-jshint": "^1.8.5",
     "mocha": "~1.14",
     "sinon": "~1.7"
   }


### PR DESCRIPTION
Gulp needs to be installed globally `npm install --global gulp`.
