### PR TITLE
#61 OpenStreetMap : streetName is sometimes undefined

### DIFF
--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -56,7 +56,7 @@ OpenStreetMapGeocoder.prototype._formatResult = function(result) {
         'city' : result.address.city,
         'state': result.address.state,
         'zipcode' : result.address.postcode,
-        'streetName': result.address.road,
+        'streetName': result.address.road || result.address.cycleway,
         'streetNumber' : result.address.house_number,
         'countryCode' : result.address.country_code
 


### PR DESCRIPTION
In some specific cases, nominatim does not returns 'road' in address but 'cycleway' for the streetName.

Ex : http://nominatim.openstreetmap.org/reverse?format=json&lat=48.8635556&lon=2.332988&zoom=18&addressdetails=1

I fix that by adding this in the lib/geocoder/openstreetmapgeocoder.js, line 58

```
'streetName': result.address.road || result.address.cycleway,
```

As this, cycleway is used as a fallback for streetName.
