### PR TITLE
OpenSteetMap : fix town result

### DIFF
--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -53,7 +53,7 @@ OpenStreetMapGeocoder.prototype._formatResult = function(result) {
         'latitude' : result.lat,
         'longitude' : result.lon,
         'country' : result.address.country,
-        'city' : result.address.city,
+        'city' : result.address.city || result.address.town,
         'state': result.address.state,
         'zipcode' : result.address.postcode,
         'streetName': result.address.road || result.address.cycleway,


### PR DESCRIPTION
In some cases, in results `city` is `town`...
Fallback it !
