### PR TITLE
Referencing Street Address Number correctly for ArcGIS provider

### DIFF
--- a/lib/geocoder/agolgeocoder.js
+++ b/lib/geocoder/agolgeocoder.js
@@ -179,7 +179,7 @@ AGOLGeocoder.prototype._formatResult = function(result) {
                 state = attributes[property];
             if(property == "StPreDir")
                 streetPreDir = attributes[property];
-            if(property == "AddrNum")
+            if(property == "AddNum")
                 streetNumber = attributes[property];
             if(property == "StName")
                 streetName = attributes[property];

--- a/lib/geocoder/agolgeocoder.js
+++ b/lib/geocoder/agolgeocoder.js
@@ -108,7 +108,7 @@ AGOLGeocoder.prototype.geocode = function(value, callback) {
             'token':token,
             'f':"json",
             'text':value,
-            'outFields': 'AddrNum,StPreDir,StName,StType,City,Postal,Region,Country'
+            'outFields': 'AddNum,StPreDir,StName,StType,City,Postal,Region,Country'
         };
 
         _this.httpAdapter.get(_this._endpoint, params, function(err, result) {

--- a/test/geocoder/agolgeocoder.js
+++ b/test/geocoder/agolgeocoder.js
@@ -137,7 +137,7 @@ describe('AGOLGeocoder', function() {
             var mock = sinon.mock(mockedRequestifyAdapter);
 
             mock.expects('get').once().callsArgWith(2, false,
-                '{"spatialReference":{"wkid":4326,"latestWkid":4326},"locations":[{"name":"380 New York St, Redlands, California, 92373","extent":{"xmin":-117.196701,"ymin":34.055489999999999,"xmax":-117.19470099999999,"ymax":34.057490000000001},"feature":{"geometry":{"x":-117.19566584280369,"y":34.056490727765947},"attributes":{"AddrNum":"","StPreDir":"","StName":"New York","StType":"St","City":"Redlands","Postal":"92373","Region":"California","Country":"USA"}}}]}'
+                '{"spatialReference":{"wkid":4326,"latestWkid":4326},"locations":[{"name":"380 New York St, Redlands, California, 92373","extent":{"xmin":-117.196701,"ymin":34.055489999999999,"xmax":-117.19470099999999,"ymax":34.057490000000001},"feature":{"geometry":{"x":-117.19566584280369,"y":34.056490727765947},"attributes":{"AddNum":"380","StPreDir":"","StName":"New York","StType":"St","City":"Redlands","Postal":"92373","Region":"California","Country":"USA"}}}]}'
             );
             var geocoder = new AGOLGeocoder(mockedRequestifyAdapter,mockedOptions);
 
@@ -156,7 +156,7 @@ describe('AGOLGeocoder', function() {
                     stateCode: null,
                     zipcode: '92373',
                     streetName: ' New York St',
-                    streetNumber: '',
+                    streetNumber: '380',
                     countryCode: 'USA'
                 });
                 mock.verify();


### PR DESCRIPTION
As per [this spec](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm#ESRI_SECTION1_42D7D3D0231241E9B656C01438209440) street address number is referenced by key `AddNum` and not `AddrNum`. The test has been updated accordingly

This PR fixes #69 