### PR TITLE
Change reverse api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,3 +143,7 @@
 ## 2.17.0
 
 * new index syntax (getGeocoder is deprecated)
+
+## 2.18.0
+
+* Made first argument of `reverse` a query object (`lat, lon` is deprecated)

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ geocoder.geocode({address: '29 champs elysée', country: 'France', zipcode: '750
 // Reverse example
 
 // Using callback
-geocoder.reverse(45.767, 4.833, function(err, res) {
+geocoder.reverse({lat:45.767, lon:4.833}, function(err, res) {
     console.log(res);
 });
 
 // Or using Promise
-geocoder.reverse(45.767, 4.833)
+geocoder.reverse({lat:45.767, lon:4.833})
     .then(function(res) {
         console.log(res);
     })
@@ -135,8 +135,8 @@ You can add new geocoders by implementing the two methods `geocode` and `reverse
 
 ```javascript
 var geocoder = {
-    geocode: function(value, callback) { },
-    reverse: function(lat, lng, callback) { }
+    geocode: function(value, callback) { ... },
+    reverse: function(query, callback) { var lat = query.lat; var lon = query.lon; ... }
 }
 ```
 

--- a/bin/geocoder-reverse
+++ b/bin/geocoder-reverse
@@ -19,7 +19,7 @@ program
       process.exit(1);
     }
 
-    geocoder.reverse(lat, long)
+    geocoder.reverse({lat:lat, lon:long})
       .then(function(results) {
         console.log(results);
       }, function(err) {

--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -24,7 +24,7 @@ Geocoder.prototype.geocode = function (value, callback) {
             if (callback && callback != 'undefined') {
                 return callback(err, data);
             }
-            return deferred.reject(err)
+            return deferred.reject(err);
         }
 
         _this._format(err, data, function(err, data) {
@@ -45,19 +45,24 @@ Geocoder.prototype.geocode = function (value, callback) {
 
 /**
 * Reverse geocoding
-* @param <number> lat  Latitude
-* @param <number> long Longitude
+* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
+* @param {function} callback Callback method
 */
-Geocoder.prototype.reverse = function (lat, long, callback) {
+Geocoder.prototype.reverse = function(query, callback) {
+    // Testing for deprecated (lat,lon,callback)-API
+    if (callback && typeof callback != 'function') {
+      return this._reverseWithLatLon.apply(this,arguments);
+    }
+
     var deferred = Q.defer(),
         _this    = this;
 
-    this._geocoder.reverse(lat, long, function(err, data) {
+    this._geocoder.reverse(query, function(err, data) {
         if (err) {
             if (callback && callback != 'undefined') {
                 return callback(err, data);
             }
-            return deferred.reject(err)
+            return deferred.reject(err);
         }
         _this._format(err, data, function(err, data) {
             if (callback && callback != 'undefined') {
@@ -73,6 +78,11 @@ Geocoder.prototype.reverse = function (lat, long, callback) {
     });
 
     return deferred.promise;
+};
+
+// * deprecated
+Geocoder.prototype._reverseWithLatLon = function (lat, lon, callback) {
+  return this.reverse({lat:lat, lon:lon}, callback);
 };
 
 /**
@@ -123,7 +133,7 @@ Geocoder.prototype._format = function (err, data, callback) {
         try {
             data = this._formatter.format(data);
         } catch(err) {
-            return callback(err)
+            return callback(err);
         }
     }
 

--- a/lib/geocoder/abstractgeocoder.js
+++ b/lib/geocoder/abstractgeocoder.js
@@ -33,16 +33,15 @@ var AbstractGeocoder = function(httpAdapter, options) {
 
 /**
 * Reverse geocoding
-* @param <integer>  lat      Latittude
-* @param <integer>  lng      Longitude
+* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
 * @param <function> callback Callback method
 */
-AbstractGeocoder.prototype.reverse = function(lat, lng, callback) {
+AbstractGeocoder.prototype.reverse = function(query, callback) {
     if (typeof this._reverse != 'function') {
         throw new Error(this.constructor.name + ' no support reverse geocoding');
     }
 
-    return this._reverse(lat, lng, callback);
+    return this._reverse(query, callback);
 };
 
 /**

--- a/lib/geocoder/agolgeocoder.js
+++ b/lib/geocoder/agolgeocoder.js
@@ -211,11 +211,13 @@ AGOLGeocoder.prototype._formatResult = function(result) {
 
 /**
  * Reverse geocoding
- * @param {number}  lat      Latitude
- * @param {number}  lng      Longitude
+ * @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
  * @param {function} callback Callback method
  */
-AGOLGeocoder.prototype.reverse = function(lat, long, callback) {
+AGOLGeocoder.prototype.reverse = function(query, callback) {
+    var lat = query.lat;
+    var long = query.lon;
+
     var _this = this;
 
     var execute = function (lat,long,token,callback) {

--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -184,11 +184,12 @@ GoogleGeocoder.prototype._formatResult = function(result) {
 
 /**
 * Reverse geocoding
-* @param <integer>  lat      Latittude
-* @param <integer>  lng      Longitude
+* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
 * @param <function> callback Callback method
 */
-GoogleGeocoder.prototype._reverse = function(lat, lng, callback) {
+GoogleGeocoder.prototype._reverse = function(query, callback) {
+    var lat = query.lat;
+    var lng = query.lon;
 
     var _this = this;
     var params = this._prepareQueryString();

--- a/lib/geocoder/mapquestgeocoder.js
+++ b/lib/geocoder/mapquestgeocoder.js
@@ -8,7 +8,7 @@ var querystring      = require('querystring'),
 var MapQuestGeocoder = function MapQuestGeocoder(httpAdapter, apiKey) {
 
     MapQuestGeocoder.super_.call(this, httpAdapter);
-    
+
     if (!apiKey || apiKey == 'undefinded') {
 
         throw new Error('MapQuestGeocoder needs an apiKey');
@@ -68,11 +68,12 @@ MapQuestGeocoder.prototype._formatResult = function(result) {
 
 /**
 * Reverse geocoding
-* @param <integer>  lat      Latittude
-* @param <integer>  lng      Longitude
+* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
 * @param <function> callback Callback method
 */
-MapQuestGeocoder.prototype._reverse = function(lat, lng, callback) {
+MapQuestGeocoder.prototype._reverse = function(query, callback) {
+    var lat = query.lat;
+    var lng = query.lon;
 
     var _this = this;
 

--- a/lib/geocoder/opencagegeocoder.js
+++ b/lib/geocoder/opencagegeocoder.js
@@ -69,11 +69,12 @@ OpenCageGeocoder.prototype._formatResult = function(result) {
 
 /**
 * Reverse geocoding
-* @param <integer>  lat      Latittude
-* @param <integer>  lng      Longitude
+* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
 * @param <function> callback Callback method
 */
-OpenCageGeocoder.prototype._reverse = function(lat, lng, callback) {
+OpenCageGeocoder.prototype._reverse = function(query, callback) {
+    var lat = query.lat;
+    var lng = query.lon;
 
     var _this = this;
 

--- a/lib/geocoder/openmapquestgeocoder.js
+++ b/lib/geocoder/openmapquestgeocoder.js
@@ -65,11 +65,12 @@ MapQuestGeocoder.prototype._formatResult = function(result) {
 
 /**
 * Reverse geocoding
-* @param <integer>  lat      Latittude
-* @param <integer>  lng      Longitude
+* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
 * @param <function> callback Callback method
 */
-MapQuestGeocoder.prototype._reverse = function(lat, lng, callback) {
+MapQuestGeocoder.prototype._reverse = function(query, callback) {
+    var lat = query.lat;
+    var lng = query.lon;
 
     var _this = this;
 

--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -79,11 +79,12 @@ OpenStreetMapGeocoder.prototype._formatResult = function(result) {
 
 /**
 * Reverse geocoding
-* @param <integer>  lat      Latittude
-* @param <integer>  lng      Longitude
+* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
 * @param <function> callback Callback method
 */
-OpenStreetMapGeocoder.prototype._reverse = function(lat, lng, callback) {
+OpenStreetMapGeocoder.prototype._reverse = function(query, callback) {
+    var lat = query.lat;
+    var lng = query.lon;
 
     var _this = this;
 

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -25,6 +25,7 @@ HttpAdapter.prototype.get = function(url, params, callback) {
 
     };
 
+    console.log(options.host + options.path);
     this.http.request(options, function(response) {
         var str = '';
         var contentType = response.headers['content-type'];
@@ -58,4 +59,3 @@ HttpAdapter.prototype.supportsHttps = function() {
 };
 
 module.exports = HttpAdapter;
-

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -25,7 +25,6 @@ HttpAdapter.prototype.get = function(url, params, callback) {
 
     };
 
-    console.log(options.host + options.path);
     this.http.request(options, function(response) {
         var str = '';
         var contentType = response.headers['content-type'];

--- a/test/geocoder/agolgeocoder.js
+++ b/test/geocoder/agolgeocoder.js
@@ -209,7 +209,7 @@ describe('AGOLGeocoder', function() {
             geocoder._getToken = function(callback) {
                 callback(false,"ABCD");
             };
-            geocoder.reverse(-104.98469734299971,39.739146640000456, function(err, results) {
+            geocoder.reverse({lat:-104.98469734299971,lon:39.739146640000456}, function(err, results) {
                     err.should.to.equal(false);
                     results[0].should.to.deep.equal({
                       latitude: 39.64942309095201,
@@ -238,7 +238,7 @@ describe('AGOLGeocoder', function() {
             geocoder._getToken = function(callback) {
                 callback(false,"ABCD");
             };
-            geocoder.reverse(40.714232,-73.9612889, function(err, results) {
+            geocoder.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                 err.should.to.deep.equal({"code":42,"message":"Random Error","details":[]});
                 mock.verify();
                 done();

--- a/test/geocoder/googlegeocoder.js
+++ b/test/geocoder/googlegeocoder.js
@@ -216,7 +216,7 @@
 
                 var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
 
-                googleAdapter.reverse(10.0235,-2.3662);
+                googleAdapter.reverse({lat:10.0235,lon:-2.3662});
 
                 mock.verify();
 
@@ -245,7 +245,7 @@
                     }]}
                 );
                 var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
-                googleAdapter.reverse(40.714232,-73.9612889, function(err, results) {
+                googleAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                         err.should.to.equal(false);
                         results[0].should.to.deep.equal({
                             "latitude"    : 40.714232,
@@ -270,7 +270,7 @@
 
                 var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
 
-                googleAdapter.reverse(40.714232,-73.9612889, function(err, results) {
+                googleAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                     err.message.should.to.equal("Status is OVER_QUERY_LIMIT. You have exceeded your rate-limit for this API.");
                     mock.verify();
                     done();
@@ -283,7 +283,7 @@
 
                 var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
 
-                googleAdapter.reverse(40.714232,-73.9612889, function(err, results) {
+                googleAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                     err.message.should.to.equal("Status is INVALID_REQUEST.");
                     mock.verify();
                     done();

--- a/test/geocoder/mapquestgeocoder.js
+++ b/test/geocoder/mapquestgeocoder.js
@@ -60,7 +60,7 @@
 
                 var mock = sinon.mock(mockedHttpAdapter);
                 mock.expects('get').withArgs(
-                    'http://www.mapquestapi.com/geocoding/v1/address', 
+                    'http://www.mapquestapi.com/geocoding/v1/address',
                     { key: "API_KEY", location: "test" }
                 ).once().returns({then: function() {}});
 
@@ -82,7 +82,7 @@
 
                 var mapquestAdapter = new MapQuestGeocoder(mockedHttpAdapter, 'API_KEY');
 
-                mapquestAdapter.reverse(10.0235,-2.3662);
+                mapquestAdapter.reverse({lat:10.0235,lon:-2.3662});
 
                 mock.verify();
 

--- a/test/geocoder/nominatimmapquestgeocoder.js
+++ b/test/geocoder/nominatimmapquestgeocoder.js
@@ -142,7 +142,7 @@
                     }
                 );
                 var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter);
-                nmAdapter.reverse(40.714232,-73.9612889, function(err, results) {
+                nmAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                     mock.verify();
                     err.should.to.equal(false);
                     results[0].should.to.deep.equal({

--- a/test/geocoder/opencagegeocoder.js
+++ b/test/geocoder/opencagegeocoder.js
@@ -190,7 +190,7 @@
                     }
                 );
                 var ocgAdapter = new OpenCageGeocoder(mockedHttpAdapter, 'API_KEY');
-                ocgAdapter.reverse(13.3826786867678, 52.51921145, function(err, results) {
+                ocgAdapter.reverse({lat:13.3826786867678, lon:52.51921145}, function(err, results) {
                         err.should.to.equal(false);
                         results[0].should.to.deep.equal({
                             "latitude": 52.51921145,

--- a/test/geocoder/openmapquestgeocoder.js
+++ b/test/geocoder/openmapquestgeocoder.js
@@ -66,7 +66,7 @@
 
                 var mapquestAdapter = new MapQuestGeocoder(mockedHttpAdapter, 'API_KEY');
 
-                mapquestAdapter.reverse(10.0235,-2.3662);
+                mapquestAdapter.reverse({lat:10.0235,lon:-2.3662});
 
                 mock.verify();
 

--- a/test/geocoder/openstreetmapgeocoder.js
+++ b/test/geocoder/openstreetmapgeocoder.js
@@ -142,7 +142,7 @@
                     }
                 );
                 var osmAdapter = new OpenStreetMapGeocoder(mockedHttpAdapter);
-                osmAdapter.reverse(40.714232,-73.9612889, function(err, results) {
+                osmAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                     mock.verify();
                     err.should.to.equal(false);
                     results[0].should.to.deep.equal({


### PR DESCRIPTION
 Made first argument of `geocoder.reverse` a query-object {lat,lon}, so further parameters can be supported by geocoders, (See PR #86), and the API is analogue to `geocode(value, callback)`.

Old (lat, long, callback)-API is still supported, so it's fully backward compatible.

Based on fixes from PR #83 and #84 