### PR TITLE
updating freegeoip zipcode response format

### DIFF
--- a/lib/geocoder/freegeoipgeocoder.js
+++ b/lib/geocoder/freegeoipgeocoder.js
@@ -32,14 +32,17 @@ FreegeoipGeocoder.prototype._geocode = function(value, callback) {
             var results = [];
 
             results.push({
-                'latitude' : result.latitude,
-                'longitude' : result.longitude,
+                'ip' : result.ip,
+                'countryCode' : result.country_code,
                 'country' : result.country_name,
+                'regionCode' : result.region_code,
+                'regionName' : result.region_name,
                 'city' : result.city,
                 'zipcode' : result.zip_code,
-                'streetName': null,
-                'streetNumber' : null,
-                'countryCode' : result.country_code
+                'timeZone' : result.time_zone,
+                'latitude' : result.latitude,
+                'longitude' : result.longitude,
+                'metroCode' : result.metro_code
 
             });
 

--- a/lib/geocoder/freegeoipgeocoder.js
+++ b/lib/geocoder/freegeoipgeocoder.js
@@ -36,7 +36,7 @@ FreegeoipGeocoder.prototype._geocode = function(value, callback) {
                 'longitude' : result.longitude,
                 'country' : result.country_name,
                 'city' : result.city,
-                'zipcode' : result.zipcode,
+                'zipcode' : result.zip_code,
                 'streetName': null,
                 'streetNumber' : null,
                 'countryCode' : result.country_code

--- a/test/geocoder/freegeoipgeocoder.js
+++ b/test/geocoder/freegeoipgeocoder.js
@@ -55,12 +55,17 @@
             it('Should return a geocoded address', function(done) {
                 var mock = sinon.mock(mockedHttpAdapter);
                 mock.expects('get').once().callsArgWith(2, false, {
-                        latitude: 37.386,
-                        longitude: -122.0838,
+                        ip: '66.249.64.0',
                         country_code: 'US',
                         country_name: 'United States',
+                        region_code: 'CA',
+                        region_name: 'California',
                         city: 'Mountain View',
-                        zip_code: 94035
+                        zip_code: '94040',
+                        time_zone: 'America/Los_Angeles',
+                        latitude: 37.386,
+                        longitude: -122.084,
+                        metro_code: 807
                     }
                 );
                 var freegeoipgeocoder = new FreegeoipGeocoder(mockedHttpAdapter);
@@ -69,14 +74,17 @@
                 freegeoipgeocoder.geocode('66.249.64.0', function(err, results) {
                     err.should.to.equal(false);
                     results[0].should.to.deep.equal({
-                        "latitude": 37.386,
-                        "longitude": -122.0838,
-                        "country": "United States",
-                        "city": "Mountain View",
-                        "zipcode": 94035,
-                        "streetName": null,
-                        "streetNumber": null,
-                        "countryCode": "US"
+                        'ip': '66.249.64.0',
+                        'countryCode': 'US',
+                        'country': 'United States',
+                        'regionCode': 'CA',
+                        'regionName': 'California',
+                        'city': 'Mountain View',
+                        'zipcode': '94040',
+                        'timeZone': 'America/Los_Angeles',
+                        'latitude': 37.386,
+                        'longitude': -122.084,
+                        'metroCode': 807
                     });
                     mock.verify();
                     done();

--- a/test/geocoder/freegeoipgeocoder.js
+++ b/test/geocoder/freegeoipgeocoder.js
@@ -60,7 +60,7 @@
                         country_code: 'US',
                         country_name: 'United States',
                         city: 'Mountain View',
-                        zipcode: 94035
+                        zip_code: 94035
                     }
                 );
                 var freegeoipgeocoder = new FreegeoipGeocoder(mockedHttpAdapter);

--- a/test/geocoder/freegeoipgeocoder.js
+++ b/test/geocoder/freegeoipgeocoder.js
@@ -64,7 +64,7 @@
                     }
                 );
                 var freegeoipgeocoder = new FreegeoipGeocoder(mockedHttpAdapter);
-                
+
 
                 freegeoipgeocoder.geocode('66.249.64.0', function(err, results) {
                     err.should.to.equal(false);
@@ -73,7 +73,7 @@
                         "longitude": -122.0838,
                         "country": "United States",
                         "city": "Mountain View",
-                        "zipcode": 94035,
+                        "zip_code": 94035,
                         "streetName": null,
                         "streetNumber": null,
                         "countryCode": "US"

--- a/test/geocoder/freegeoipgeocoder.js
+++ b/test/geocoder/freegeoipgeocoder.js
@@ -73,7 +73,7 @@
                         "longitude": -122.0838,
                         "country": "United States",
                         "city": "Mountain View",
-                        "zip_code": 94035,
+                        "zipcode": 94035,
                         "streetName": null,
                         "streetNumber": null,
                         "countryCode": "US"


### PR DESCRIPTION
It appears freegeoip's format for their response JSON has changed. It now uses zip_code. See this example:
https://freegeoip.net/json/github.com