### PR TITLE
Fix nominatimmapquest and openstreetmap reverse function

### DIFF
--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -21,7 +21,10 @@ HttpAdapter.prototype.get = function(url, params, callback) {
     var urlParsed = this.url.parse(url);
     var options = {
         host: urlParsed.host,
-        path: urlParsed.path + '?' + querystring.stringify(params)
+        path: urlParsed.path + '?' + querystring.stringify(params),
+        headers : {
+            "user-agent" : "Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/31.0"
+        }
 
     };
 


### PR DESCRIPTION
The reverse function of openstreetmap and nominatimmapquest doesn't accept nodejs/iojs default http user-agent anymore.
I added a custom user-agent (firefox 31.0 on linux) to prevent the issue.