### PR TITLE
Add confidence to geocodes & added geocodio module

### DIFF
--- a/lib/geocoder/geocodio.js
+++ b/lib/geocoder/geocodio.js
@@ -50,8 +50,6 @@ GeocodioGeocoder.prototype._geocode = function (value, callback) {
 };
 
 GeocodioGeocoder.prototype._formatResult = function (result) {
-  console.log(result);
-  //console.log(MQConfidenceLookup[result.geocodeQuality]);
   var accuracy = (result.accuracy < 1) ? result.accuracy - .1 : 1
   return {
     'latitude': result.location.lat,
@@ -82,7 +80,7 @@ GeocodioGeocoder.prototype._reverse = function (query, callback) {
 
   this.httpAdapter.get(this._endpoint + '/reverse', {
     'q': lat + ',' + lng,
-    'key': querystring.unescape(this.apiKey)
+    'api_key': querystring.unescape(this.apiKey)
   }, function (err, result) {
     if (err) return callback(err);
     var results = [];

--- a/lib/geocoder/geocodio.js
+++ b/lib/geocoder/geocodio.js
@@ -1,0 +1,100 @@
+var querystring = require('querystring'),
+  util = require('util'),
+  AbstractGeocoder = require('./abstractgeocoder');
+
+/**
+ * Constructor
+ */
+var GeocodioGeocoder = function GeocodioGeocoder(httpAdapter, apiKey) {
+
+  GeocodioGeocoder.super_.call(this, httpAdapter);
+
+  if (!apiKey || apiKey == 'undefinded') {
+
+    throw new Error(this.constructor.name + ' needs an apiKey');
+  }
+
+  this.apiKey = apiKey;
+  this._endpoint = 'http://api.geocod.io/v1';
+};
+
+util.inherits(GeocodioGeocoder, AbstractGeocoder);
+
+/**
+ * Geocode
+ * @param <string>   value    Value to geocode (Address)
+ * @param <function> callback Callback method
+ */
+GeocodioGeocoder.prototype._geocode = function (value, callback) {
+  var _this = this;
+  this.httpAdapter.get(this._endpoint + '/geocode', {
+    'q': value,
+    'api_key': querystring.unescape(this.apiKey)
+  }, function (err, result) {
+    if (err) return callback(err);
+    if (result.error) {
+      return callback(new Error('Status is ' + result.error), {raw: result});
+    }
+
+    var results = [];
+
+    var locations = result.results;
+
+    for (var i = 0; i < locations.length; i++) {
+      results.push(_this._formatResult(locations[i]));
+    }
+
+    results.raw = result;
+    callback(false, results);
+  });
+};
+
+GeocodioGeocoder.prototype._formatResult = function (result) {
+  console.log(result);
+  //console.log(MQConfidenceLookup[result.geocodeQuality]);
+  var accuracy = (result.accuracy < 1) ? result.accuracy - .1 : 1
+  return {
+    'latitude': result.location.lat,
+    'longitude': result.location.lng,
+    'country': null,
+    'city': result.address_components.city,
+    'state': result.address_components.state,
+    'zipcode': result.address_components.zip,
+    'streetName': result.address_components.formatted_street,
+    'streetNumber': result.address_components.number,
+    'countryCode': null,
+    'extra': {
+      confidence: accuracy || 0
+    }
+  };
+};
+
+/**
+ * Reverse geocoding
+ * @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
+ * @param <function> callback Callback method
+ */
+GeocodioGeocoder.prototype._reverse = function (query, callback) {
+  var lat = query.lat;
+  var lng = query.lon;
+
+  var _this = this;
+
+  this.httpAdapter.get(this._endpoint + '/reverse', {
+    'q': lat + ',' + lng,
+    'key': querystring.unescape(this.apiKey)
+  }, function (err, result) {
+    if (err) return callback(err);
+    var results = [];
+    var locations = result.results;
+
+    for (var i = 0; i < locations.length; i++) {
+      results.push(_this._formatResult(locations[i]));
+    }
+
+    results.raw = result;
+    callback(false, results);
+  });
+};
+
+module.exports = GeocodioGeocoder;

--- a/lib/geocoder/geocodiogeocoder.js
+++ b/lib/geocoder/geocodiogeocoder.js
@@ -50,7 +50,7 @@ GeocodioGeocoder.prototype._geocode = function (value, callback) {
 };
 
 GeocodioGeocoder.prototype._formatResult = function (result) {
-  var accuracy = (result.accuracy < 1) ? result.accuracy - .1 : 1
+  var accuracy = (result.accuracy < 1) ? result.accuracy - 0.1 : 1;
   return {
     'latitude': result.location.lat,
     'longitude': result.location.lng,

--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -135,14 +135,18 @@ GoogleGeocoder.prototype._formatResult = function (result) {
     GEOMETRIC_CENTER: 0.7,
     APPROXIMATE: 0.5
   };
-
+  console.log(googleConfidenceLookup[result.geometry.location_type]);
   var extractedObj = {
-    formattedAddress: result.formatted_address,
+    formattedAddress: result.formatted_address || null,
     latitude: result.geometry.location.lat,
-    longitude: result.geometry.location.lat,
+    longitude: result.geometry.location.lng,
     extra: {
-      googlePlaceId: result.place_id,
+      googlePlaceId: result.place_id || null,
       confidence: googleConfidenceLookup[result.geometry.location_type] || 0,
+      premise: null,
+      subpremise: null,
+      neighborhood: null,
+      establishment: null
     }
   };
 
@@ -187,7 +191,7 @@ GoogleGeocoder.prototype._formatResult = function (result) {
         break;
     }
   }
-  return extractedObj
+  return extractedObj;
 };
 
 /**

--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -1,7 +1,7 @@
-var crypto           = require('crypto'),
-    url              = require('url'),
-    util             = require('util'),
-    AbstractGeocoder = require('./abstractgeocoder');
+var crypto = require('crypto'),
+  url = require('url'),
+  util = require('util'),
+  AbstractGeocoder = require('./abstractgeocoder');
 
 /**
  * Constructor
@@ -9,17 +9,17 @@ var crypto           = require('crypto'),
  * @param <object> options     Options (language, clientId, apiKey, region)
  */
 var GoogleGeocoder = function GoogleGeocoder(httpAdapter, options) {
-    this.options = ['language', 'apiKey', 'clientId', 'region'];
+  this.options = ['language', 'apiKey', 'clientId', 'region'];
 
-    GoogleGeocoder.super_.call(this, httpAdapter, options);
+  GoogleGeocoder.super_.call(this, httpAdapter, options);
 
-    if (this.options.clientId && !this.options.apiKey) {
-        throw new Error('You must specify a apiKey (privateKey)');
-    }
+  if (this.options.clientId && !this.options.apiKey) {
+    throw new Error('You must specify a apiKey (privateKey)');
+  }
 
-    if (this.options.apiKey && !httpAdapter.supportsHttps()) {
-        throw new Error('You must use https http adapter');
-    }
+  if (this.options.apiKey && !httpAdapter.supportsHttps()) {
+    throw new Error('You must use https http adapter');
+  }
 };
 
 util.inherits(GoogleGeocoder, AbstractGeocoder);
@@ -28,222 +28,201 @@ util.inherits(GoogleGeocoder, AbstractGeocoder);
 GoogleGeocoder.prototype._endpoint = 'https://maps.googleapis.com/maps/api/geocode/json';
 
 /**
-* Geocode
-* @param <string>   value    Value to geocode (Address)
-* @param <function> callback Callback method
-*/
-GoogleGeocoder.prototype._geocode = function(value, callback) {
+ * Geocode
+ * @param <string>   value    Value to geocode (Address)
+ * @param <function> callback Callback method
+ */
+GoogleGeocoder.prototype._geocode = function (value, callback) {
 
-    var _this = this;
-    var params = this._prepareQueryString();
+  var _this = this;
+  var params = this._prepareQueryString();
 
-    if (value.address && value.address != 'undefinded') {
-        var components = null;
+  if (value.address && value.address != 'undefinded') {
+    var components = null;
 
-        if (value.country && value.country != 'undefinded') {
-            components = 'country:'+ value.country;
-        }
+    if (value.country && value.country != 'undefinded') {
+      components = 'country:' + value.country;
+    }
 
-        if (value.zipcode && value.zipcode != 'undefinded') {
-            if (components) {
-                components += '|';
-            }
-            components += 'postal_code:'+ value.zipcode;
-        }
+    if (value.zipcode && value.zipcode != 'undefinded') {
+      if (components) {
+        components += '|';
+      }
+      components += 'postal_code:' + value.zipcode;
+    }
 
-        params.components = components;
-        params.address = value.address;
+    params.components = components;
+    params.address = value.address;
+  } else {
+    params.address = value;
+  }
+
+  this._signedRequest(this._endpoint, params);
+  this.httpAdapter.get(this._endpoint, params, function (err, result) {
+    if (err) {
+      return callback(err);
     } else {
-        params.address = value;
+      // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
+      // error_message may or may not be present
+      if (result.status === 'ZERO_RESULTS') {
+        results = [];
+        results.raw = result;
+        return callback(false, results);
+      }
+
+      if (result.status !== 'OK') {
+        return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')), {raw: result});
+      }
+
+      var results = [];
+
+      for (var i = 0; i < result.results.length; i++) {
+        results.push(_this._formatResult(result.results[i]));
+      }
+
+      results.raw = result;
+      callback(false, results);
     }
 
-    this._signedRequest(this._endpoint, params);
-    this.httpAdapter.get(this._endpoint, params, function(err, result) {
-        if (err) {
-            return callback(err);
-        } else {
-            // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
-            // error_message may or may not be present
-            if (result.status === 'ZERO_RESULTS') {
-                results = [];
-                results.raw = result;
-                return callback(false, results);
-            }
-
-            if (result.status !== 'OK') {
-                return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')),{raw:result});
-            }
-
-            var results = [];
-
-            for(var i = 0; i < result.results.length; i++) {
-                results.push(_this._formatResult(result.results[i]));
-            }
-
-            results.raw = result;
-            callback(false, results);
-        }
-
-    });
+  });
 
 };
 
-GoogleGeocoder.prototype._prepareQueryString = function() {
-    var params = {
-        'sensor' : false
-    };
+GoogleGeocoder.prototype._prepareQueryString = function () {
+  var params = {
+    'sensor': false
+  };
 
-    if (this.options.language) {
-        params.language = this.options.language;
-    }
+  if (this.options.language) {
+    params.language = this.options.language;
+  }
 
-    if (this.options.region) {
-        params.region = this.options.region;
-    }
+  if (this.options.region) {
+    params.region = this.options.region;
+  }
 
-    if (this.options.clientId) {
-        params.client = this.options.clientId;
-    } else if (this.options.apiKey) {
-        params.key = this.options.apiKey;
-    }
+  if (this.options.clientId) {
+    params.client = this.options.clientId;
+  } else if (this.options.apiKey) {
+    params.key = this.options.apiKey;
+  }
 
-    return params;
+  return params;
 };
 
-GoogleGeocoder.prototype._signedRequest = function(endpoint, params) {
-    if (this.options.clientId) {
-        var request = url.parse(endpoint);
-        var fullRequestPath = request.path + url.format({ query: params });
-        var decodedKey = new Buffer(this.options.apiKey.replace('-', '+').replace('_', '/'), 'base64').toString('binary');
-        var hmac = crypto.createHmac('sha1', decodedKey);
-        hmac.update(fullRequestPath);
-        var signature = hmac.digest('base64');
+GoogleGeocoder.prototype._signedRequest = function (endpoint, params) {
+  if (this.options.clientId) {
+    var request = url.parse(endpoint);
+    var fullRequestPath = request.path + url.format({query: params});
+    var decodedKey = new Buffer(this.options.apiKey.replace('-', '+').replace('_', '/'), 'base64').toString('binary');
+    var hmac = crypto.createHmac('sha1', decodedKey);
+    hmac.update(fullRequestPath);
+    var signature = hmac.digest('base64');
 
-        signature = signature.replace(/\+/g, '-').replace(/\//g, '_');
+    signature = signature.replace(/\+/g, '-').replace(/\//g, '_');
 
-        params.signature = signature;
-    }
+    params.signature = signature;
+  }
 
-    return params;
+  return params;
 };
 
-GoogleGeocoder.prototype._formatResult = function(result) {
+GoogleGeocoder.prototype._formatResult = function (result) {
 
-    var country = null;
-    var countryCode = null;
-    var city = null;
-    var state = null;
-    var stateCode = null;
-    var zipcode = null;
-    var streetName = null;
-    var streetNumber = null;
-    var formattedAddress = result.formatted_address ? result.formatted_address : null;
-    var googlePlaceId = result.place_id ? result.place_id : null;
-    var premise = null;
-    var subpremise = null;
-    var establishment = null;
-    var neighborhood = null;
+  var googleConfidenceLookup = {
+    ROOFTOP: 1,
+    RANGE_INTERPOLATED: 0.9,
+    GEOMETRIC_CENTER: 0.7,
+    APPROXIMATE: 0.5
+  };
 
-    for (var i = 0; i < result.address_components.length; i++) {
-        // Country
-        if (result.address_components[i].types.indexOf('country') >= 0) {
-            country = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('country') >= 0) {
-            countryCode = result.address_components[i].short_name;
-        }
-        // State
-        if (result.address_components[i].types.indexOf('administrative_area_level_1') >= 0) {
-            state = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('administrative_area_level_1') >= 0) {
-            stateCode = result.address_components[i].short_name;
-        }
-        // City
-        if (result.address_components[i].types.indexOf('locality') >= 0) {
-            city = result.address_components[i].long_name;
-        }
-        // Address
-        if (result.address_components[i].types.indexOf('postal_code') >= 0) {
-            zipcode = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('route') >= 0) {
-            streetName = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('street_number') >= 0) {
-            streetNumber = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('premise') >= 0) {
-            premise = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('subpremise') >= 0) {
-            subpremise = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('establishment') >= 0) {
-            establishment = result.address_components[i].long_name;
-        }
-        if (result.address_components[i].types.indexOf('neighborhood') >= 0) {
-            neighborhood = result.address_components[i].long_name;
-        }
+  var extractedObj = {
+    formattedAddress: result.formatted_address,
+    latitude: result.geometry.location.lat,
+    longitude: result.geometry.location.lat,
+    extra: {
+      googlePlaceId: result.place_id,
+      confidence: googleConfidenceLookup[result.geometry.location_type] || 0,
     }
+  };
 
-
-    return {
-        'latitude' : result.geometry.location.lat,
-        'longitude' : result.geometry.location.lng,
-        'country' : country,
-        'city' : city,
-        'state' : state,
-        'stateCode' : stateCode,
-        'zipcode' : zipcode,
-        'streetName': streetName,
-        'streetNumber' : streetNumber,
-        'countryCode' : countryCode,
-        'formattedAddress': formattedAddress,
-        'extra': {
-            'googlePlaceId': googlePlaceId,
-            'premise': premise,
-            'subpremise': subpremise,
-            'neighborhood': neighborhood,
-            'establishment': establishment
-        }
-    };
-
+  for (var i = 0; i < result.address_components.length; i++) {
+    var addressType = result.address_components[i].types[0];
+    switch (addressType) {
+      //Country
+      case 'country':
+        extractedObj.country = result.address_components[i].long_name;
+        extractedObj.countryCode = result.address_components[i].short_name;
+        break;
+      //State
+      case 'administrative_area_level_1':
+        extractedObj.state = result.address_components[i].long_name;
+        extractedObj.stateCode = result.address_components[i].short_name;
+        break;
+      // City
+      case 'locality':
+        extractedObj.city = result.address_components[i].long_name;
+        break;
+      // Address
+      case 'postal_code':
+        extractedObj.zipcode = result.address_components[i].long_name;
+        break;
+      case 'route':
+        extractedObj.streetName = result.address_components[i].long_name;
+        break;
+      case 'street_number':
+        extractedObj.streetNumber = result.address_components[i].long_name;
+        break;
+      case 'premise':
+        extractedObj.extra.premise = result.address_components[i].long_name;
+        break;
+      case 'subpremise':
+        extractedObj.extra.subpremise = result.address_components[i].long_name;
+        break;
+      case 'establishment':
+        extractedObj.extra.establishment = result.address_components[i].long_name;
+        break;
+      case 'neighborhood':
+        extractedObj.extra.neighborhood = result.address_components[i].long_name;
+        break;
+    }
+  }
+  return extractedObj
 };
 
 /**
-* Reverse geocoding
-* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
-* @param <function> callback Callback method
-*/
-GoogleGeocoder.prototype._reverse = function(query, callback) {
-    var lat = query.lat;
-    var lng = query.lon;
+ * Reverse geocoding
+ * @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
+ * @param <function> callback Callback method
+ */
+GoogleGeocoder.prototype._reverse = function (query, callback) {
+  var lat = query.lat;
+  var lng = query.lon;
 
-    var _this = this;
-    var params = this._prepareQueryString();
-    params.latlng = lat + ',' + lng;
-    this._signedRequest(this._endpoint, params);
-    this.httpAdapter.get(this._endpoint , params, function(err, result) {
-        if (err) {
-            return callback(err);
-        } else {
-            // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
-            // error_message may or may not be present
-            if (result.status !== 'OK') {
-                return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')),{raw:result});
-            }
+  var _this = this;
+  var params = this._prepareQueryString();
+  params.latlng = lat + ',' + lng;
+  this._signedRequest(this._endpoint, params);
+  this.httpAdapter.get(this._endpoint, params, function (err, result) {
+    if (err) {
+      return callback(err);
+    } else {
+      // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
+      // error_message may or may not be present
+      if (result.status !== 'OK') {
+        return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')), {raw: result});
+      }
 
-            var results = [];
+      var results = [];
 
-            if(result.results.length > 0) {
-                results.push(_this._formatResult(result.results[0]));
-            }
+      if (result.results.length > 0) {
+        results.push(_this._formatResult(result.results[0]));
+      }
 
-            results.raw = result;
-            callback(false, results);
-        }
-    });
+      results.raw = result;
+      callback(false, results);
+    }
+  });
 };
 
 module.exports = GoogleGeocoder;

--- a/lib/geocoder/opencagegeocoder.js
+++ b/lib/geocoder/opencagegeocoder.js
@@ -54,8 +54,8 @@ OpenCageGeocoder.prototype._geocode = function (value, callback) {
 
 OpenCageGeocoder.prototype._formatResult = function (result) {
   var openCageConfidence = {
-    10: 1, // < .25km
-    9: 0.9, // < .5km
+    10: 0.9, // < .25km
+    9: 0.8, // < .5km
     8: 0.8, // < 1km
     7: 0.7, // < 5km
     6: 0.6, // < 7.5km

--- a/lib/geocoder/opencagegeocoder.js
+++ b/lib/geocoder/opencagegeocoder.js
@@ -1,119 +1,134 @@
-var util             = require('util'),
-    AbstractGeocoder = require('./abstractgeocoder');
+var util = require('util'),
+  AbstractGeocoder = require('./abstractgeocoder');
 
 /**
  * Constructor
  */
 var OpenCageGeocoder = function OpenCageGeocoder(httpAdapter, apiKey, options) {
-    this.options = ['language'];
+  this.options = ['language'];
 
-    OpenCageGeocoder.super_.call(this, httpAdapter, options);
+  OpenCageGeocoder.super_.call(this, httpAdapter, options);
 
-    if (!apiKey || apiKey == 'undefinded') {
-        throw new Error(this.constructor.name + ' needs an apiKey');
-    }
+  if (!apiKey || apiKey == 'undefinded') {
+    throw new Error(this.constructor.name + ' needs an apiKey');
+  }
 
-    this.apiKey = apiKey;
-    this._endpoint = 'http://api.opencagedata.com/geocode/v1/json';
+  this.apiKey = apiKey;
+  this._endpoint = 'http://api.opencagedata.com/geocode/v1/json';
 };
 
 util.inherits(OpenCageGeocoder, AbstractGeocoder);
 
 /**
-* Geocode
-* @param <string>   value    Value to geocode (Address)
-* @param <function> callback Callback method
-*/
-OpenCageGeocoder.prototype._geocode = function(value, callback) {
-    var _this = this;
+ * Geocode
+ * @param <string>   value    Value to geocode (Address)
+ * @param <function> callback Callback method
+ */
+OpenCageGeocoder.prototype._geocode = function (value, callback) {
+  var _this = this;
 
-    var params = this._getCommonParams();
-    params.q = value;
+  var params = this._getCommonParams();
+  params.q = value;
 
-    this.httpAdapter.get(this._endpoint, params, function(err, result) {
+  this.httpAdapter.get(this._endpoint, params, function (err, result) {
 
-        if (err) {
-            return callback(err);
-        } else {
+    if (err) {
+      return callback(err);
+    } else {
 
-            var results = [];
+      var results = [];
 
-			if (result && result.results instanceof Array) {
-				for (var i = 0; i < result.results.length; i++) {
-					results.push(_this._formatResult(result.results[i]));
-				}
-			}
-
-            results.raw = result;
-            callback(false, results);
+      if (result && result.results instanceof Array) {
+        for (var i = 0; i < result.results.length; i++) {
+          results.push(_this._formatResult(result.results[i]));
         }
+      }
 
-    });
-
-};
-
-OpenCageGeocoder.prototype._formatResult = function(result) {
-
-    return {
-        'latitude' : result.geometry.lat,
-        'longitude' : result.geometry.lng,
-        'country' : result.components.country,
-        'city' : result.components.city,
-        'state' : result.components.state,
-        'zipcode' : result.components.postcode,
-        'streetName': result.components.road,
-        'streetNumber' : result.components.house_number,
-        'countryCode' : result.components.country_code,
-        'county': result.components.county
-    };
-};
-
-/**
-* Reverse geocoding
-* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
-* @param <function> callback Callback method
-*/
-OpenCageGeocoder.prototype._reverse = function(query, callback) {
-    var lat = query.lat;
-    var lng = query.lon;
-
-    var _this = this;
-
-    var params = this._getCommonParams();
-    params.q = lat + ' ' + lng;
-
-    this.httpAdapter.get(this._endpoint, params, function(err, result) {
-        if (err) {
-            throw err;
-        } else {
-            var results = [];
-
-            if (result && result.results instanceof Array) {
-                for (var i = 0; i < result.results.length; i++) {
-                    results.push(_this._formatResult(result.results[i]));
-                }
-            }
-
-            results.raw = result;
-            callback(false, results);
-        }
-    });
-};
-
-/**
-* Prepare common params
-*
-* @return <Object> common params
-*/
-OpenCageGeocoder.prototype._getCommonParams = function(){
-    var params = {};
-    params.key = this.apiKey;
-
-    if (this.options.language) {
-        params.language = this.options.language;
+      results.raw = result;
+      callback(false, results);
     }
 
-    return params;
+  });
+
+};
+
+OpenCageGeocoder.prototype._formatResult = function (result) {
+  var openCageConfidence = {
+    10: 1, // < .25km
+    9: 0.9, // < .5km
+    8: 0.8, // < 1km
+    7: 0.7, // < 5km
+    6: 0.6, // < 7.5km
+    5: 0.6, // < 10km
+    4: 0.5, // < 15km
+    3: 0.4, // < 15km
+    2: 0.4, // < 25km
+    1: 0.3, // > 25km
+    0: 0 // NA
+  }
+  return {
+    'latitude': result.geometry.lat,
+    'longitude': result.geometry.lng,
+    'country': result.components.country,
+    'city': result.components.city,
+    'state': result.components.state,
+    'zipcode': result.components.postcode,
+    'streetName': result.components.road,
+    'streetNumber': result.components.house_number,
+    'countryCode': result.components.country_code,
+    'county': result.components.county,
+    'extra': {
+      confidence: openCageConfidence[result.confidence] || 0
+    }
+  };
+};
+
+/**
+ * Reverse geocoding
+ * @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
+ * @param <function> callback Callback method
+ */
+OpenCageGeocoder.prototype._reverse = function (query, callback) {
+  var lat = query.lat;
+  var lng = query.lon;
+
+  var _this = this;
+
+  var params = this._getCommonParams();
+  params.q = lat + ' ' + lng;
+
+  this.httpAdapter.get(this._endpoint, params, function (err, result) {
+    if (err) {
+      throw err;
+    } else {
+      var results = [];
+
+      if (result && result.results instanceof Array) {
+        for (var i = 0; i < result.results.length; i++) {
+          results.push(_this._formatResult(result.results[i]));
+        }
+      }
+
+      results.raw = result;
+      callback(false, results);
+    }
+  });
+};
+
+/**
+ * Prepare common params
+ *
+ * @return <Object> common params
+ */
+OpenCageGeocoder.prototype._getCommonParams = function () {
+  var params = {};
+  params.key = this.apiKey;
+
+  if (this.options.language) {
+    params.language = this.options.language;
+  }
+
+  return params;
 };
 
 module.exports = OpenCageGeocoder;

--- a/lib/geocoder/opencagegeocoder.js
+++ b/lib/geocoder/opencagegeocoder.js
@@ -65,7 +65,7 @@ OpenCageGeocoder.prototype._formatResult = function (result) {
     2: 0.4, // < 25km
     1: 0.3, // > 25km
     0: 0 // NA
-  }
+  };
   return {
     'latitude': result.geometry.lat,
     'longitude': result.geometry.lng,

--- a/lib/geocoder/openmapquestgeocoder.js
+++ b/lib/geocoder/openmapquestgeocoder.js
@@ -1,96 +1,119 @@
-var querystring      = require('querystring'),
-    util             = require('util'),
-    AbstractGeocoder = require('./abstractgeocoder');
+var querystring = require('querystring'),
+  util = require('util'),
+  AbstractGeocoder = require('./abstractgeocoder');
 
 /**
  * Constructor
  */
 var MapQuestGeocoder = function OpenMapQuestGeocoder(httpAdapter, apiKey) {
 
-    MapQuestGeocoder.super_.call(this, httpAdapter);
+  MapQuestGeocoder.super_.call(this, httpAdapter);
 
-    if (!apiKey || apiKey == 'undefinded') {
+  if (!apiKey || apiKey == 'undefinded') {
 
-        throw new Error(this.constructor.name + ' needs an apiKey');
-    }
+    throw new Error(this.constructor.name + ' needs an apiKey');
+  }
 
-    this.apiKey = apiKey;
-    this._endpoint = 'http://open.mapquestapi.com/geocoding/v1';
+  this.apiKey = apiKey;
+  this._endpoint = 'http://open.mapquestapi.com/geocoding/v1';
 };
 
 util.inherits(MapQuestGeocoder, AbstractGeocoder);
 
 /**
-* Geocode
-* @param <string>   value    Value to geocode (Address)
-* @param <function> callback Callback method
-*/
-MapQuestGeocoder.prototype._geocode = function(value, callback) {
-    var _this = this;
-    this.httpAdapter.get(this._endpoint + '/address' , { 'location' : value, 'key' : querystring.unescape(this.apiKey)}, function(err, result) {
-        if (err) {
-            return callback(err);
-        } else {
-            if (result.info.statuscode !== 0) {
-                return callback(new Error('Status is ' + result.info.statuscode + ' ' + result.info.messages[0]),{raw:result});
-            }
+ * Geocode
+ * @param <string>   value    Value to geocode (Address)
+ * @param <function> callback Callback method
+ */
+MapQuestGeocoder.prototype._geocode = function (value, callback) {
+  var _this = this;
+  this.httpAdapter.get(this._endpoint + '/address', {
+    'location': value,
+    'key': querystring.unescape(this.apiKey)
+  }, function (err, result) {
+    if (err) {
+      return callback(err);
+    } else {
+      if (result.info.statuscode !== 0) {
+        return callback(new Error('Status is ' + result.info.statuscode + ' ' + result.info.messages[0]), {raw: result});
+      }
 
-            var results = [];
+      var results = [];
 
-            var locations = result.results[0].locations;
+      var locations = result.results[0].locations;
 
-            for(var i = 0; i < locations.length; i++) {
-                results.push(_this._formatResult(locations[i]));
-            }
+      for (var i = 0; i < locations.length; i++) {
+        results.push(_this._formatResult(locations[i]));
+      }
 
-            results.raw = result;
-            callback(false, results);
-        }
-    });
+      results.raw = result;
+      callback(false, results);
+    }
+  });
 };
 
-MapQuestGeocoder.prototype._formatResult = function(result) {
+MapQuestGeocoder.prototype._formatResult = function (result) {
+  var MQConfidenceLookup = {
+    POINT: 1,
+    ADDRESS:.9,
+    INTERSECTION: 0.8, //less accurate than the MQ description
+    STREET: 0.7,
+    ZIP: 0.5,
+    ZIP_EXTENDED: 0.5,
+    NEIGHBORHOOD: 0.5,
+    CITY: 0.4,
+    COUNTY: 0.3,
+    STATE: 0.2,
+    COUNTRY: 0.1
+  };
+  console.log(result.geocodeQuality);
+  console.log(MQConfidenceLookup[result.geocodeQuality]);
+  return {
+    'latitude': result.latLng.lat,
+    'longitude': result.latLng.lng,
+    'country': null,
+    'countryCode': result.adminArea1,
+    'city': result.adminArea5,
+    'state': result.adminArea3,
+    'zipcode': result.postalCode,
+    'streetName': result.street,
+    'streetNumber': null,
+    'extra': {
+      confidence: MQConfidenceLookup[result.geocodeQuality] || 0
+    }
 
-    return {
-        'latitude' : result.latLng.lat,
-        'longitude' : result.latLng.lng,
-        'country' : null,
-        'city' : result.adminArea5,
-        'zipcode' : result.postalCode,
-        'streetName': result.street,
-        'streetNumber' : null,
-        'countryCode' : result.adminArea1
-
-    };
+  };
 };
 
 /**
-* Reverse geocoding
-* @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
-* @param <function> callback Callback method
-*/
-MapQuestGeocoder.prototype._reverse = function(query, callback) {
-    var lat = query.lat;
-    var lng = query.lon;
+ * Reverse geocoding
+ * @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
+ * @param <function> callback Callback method
+ */
+MapQuestGeocoder.prototype._reverse = function (query, callback) {
+  var lat = query.lat;
+  var lng = query.lon;
 
-    var _this = this;
+  var _this = this;
 
-    this.httpAdapter.get(this._endpoint + '/reverse' , { 'location' : lat + ',' + lng, 'key' : querystring.unescape(this.apiKey)}, function(err, result) {
-        if (err) {
-            return callback(err);
-        } else {
-            var results = [];
+  this.httpAdapter.get(this._endpoint + '/reverse', {
+    'location': lat + ',' + lng,
+    'key': querystring.unescape(this.apiKey)
+  }, function (err, result) {
+    if (err) {
+      return callback(err);
+    } else {
+      var results = [];
+      var locations = result.results[0].locations;
 
-            var locations = result.results[0].locations;
+      for (var i = 0; i < locations.length; i++) {
+        results.push(_this._formatResult(locations[i]));
+      }
 
-            for(var i = 0; i < locations.length; i++) {
-                results.push(_this._formatResult(locations[i]));
-            }
-
-            results.raw = result;
-            callback(false, results);
-        }
-    });
+      results.raw = result;
+      callback(false, results);
+    }
+  });
 };
 
 module.exports = MapQuestGeocoder;

--- a/lib/geocoder/openmapquestgeocoder.js
+++ b/lib/geocoder/openmapquestgeocoder.js
@@ -66,8 +66,6 @@ MapQuestGeocoder.prototype._formatResult = function (result) {
     STATE: 0.2,
     COUNTRY: 0.1
   };
-  console.log(result.geocodeQuality);
-  console.log(MQConfidenceLookup[result.geocodeQuality]);
   return {
     'latitude': result.latLng.lat,
     'longitude': result.latLng.lng,

--- a/lib/geocoder/openmapquestgeocoder.js
+++ b/lib/geocoder/openmapquestgeocoder.js
@@ -55,7 +55,7 @@ MapQuestGeocoder.prototype._geocode = function (value, callback) {
 MapQuestGeocoder.prototype._formatResult = function (result) {
   var MQConfidenceLookup = {
     POINT: 1,
-    ADDRESS:.9,
+    ADDRESS: 0.9,
     INTERSECTION: 0.8, //less accurate than the MQ description
     STREET: 0.7,
     ZIP: 0.5,

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -70,7 +70,7 @@
 				return new OpenMapQuestGeocoder(adapter, extra.apiKey);
 			}
       if (geocoderName === 'geocodio') {
-        var GeocodioGeocoder = new require('./geocoder/geocodio.js');
+        var GeocodioGeocoder = new require('./geocoder/geocodiogeocoder.js');
 
         return new GeocodioGeocoder(adapter, extra.apiKey);
       }

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -69,6 +69,11 @@
 
 				return new OpenMapQuestGeocoder(adapter, extra.apiKey);
 			}
+      if (geocoderName === 'geocodio') {
+        var GeocodioGeocoder = new require('./geocoder/geocodio.js');
+
+        return new GeocodioGeocoder(adapter, extra.apiKey);
+      }
 			if (geocoderName === 'opencage') {
 				var OpenCageGeocoder = new require('./geocoder/opencagegeocoder.js');
 				return new OpenCageGeocoder(adapter, extra.apiKey, extra);

--- a/test/geocoder/geocodiogeocoder.js
+++ b/test/geocoder/geocodiogeocoder.js
@@ -1,0 +1,79 @@
+(function() {
+    var chai = require('chai'),
+        should = chai.should(),
+        expect = chai.expect,
+        sinon = require('sinon');
+
+    var GeocodioGeocoder = require('../../lib/geocoder/geocodiogeocoder.js');
+    var HttpAdapter = require('../../lib/httpadapter/httpadapter.js');
+
+    var mockedHttpAdapter = {
+        get: function() {}
+    };
+
+    describe('GeocodioGeocoder', function() {
+
+        describe('#constructor' , function() {
+
+            it('an http adapter must be set', function() {
+
+                expect(function() {new GeocodioGeocoder();}).to.throw(Error, 'GeocodioGeocoder need an httpAdapter');
+            });
+
+            it('an apiKey must be set', function() {
+
+                expect(function() {new GeocodioGeocoder(mockedHttpAdapter);}).to.throw(Error, 'GeocodioGeocoder needs an apiKey');
+            });
+
+            it('Should be an instance of GeocodioGeocoder', function() {
+
+                var mapquestAdapter = new GeocodioGeocoder(mockedHttpAdapter, 'API_KEY');
+
+                mapquestAdapter.should.be.instanceof(GeocodioGeocoder);
+            });
+
+        });
+
+        describe('#geocode' , function() {
+
+            it('Should not accept IPv4', function() {
+
+                var mapquestAdapter = new GeocodioGeocoder(mockedHttpAdapter, 'API_KEY');
+
+                expect(function() {
+                        mapquestAdapter.geocode('127.0.0.1');
+                }).to.throw(Error, 'GeocodioGeocoder does not support geocoding IPv4');
+
+            });
+
+            it('Should not accept IPv6', function() {
+
+                var mapquestAdapter = new GeocodioGeocoder(mockedHttpAdapter, 'API_KEY');
+
+                expect(function() {
+                        mapquestAdapter.geocode('2001:0db8:0000:85a3:0000:0000:ac1f:8001');
+                }).to.throw(Error, 'GeocodioGeocoder does not support geocoding IPv6');
+
+            });
+
+        });
+
+        describe('#reverse' , function() {
+            it('Should call httpAdapter get method', function() {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().returns({then: function() {}});
+
+                var mapquestAdapter = new GeocodioGeocoder(mockedHttpAdapter, 'API_KEY');
+
+                mapquestAdapter.reverse({lat:10.0235,lon:-2.3662});
+
+                mock.verify();
+            });
+
+        });
+
+
+    });
+
+})();

--- a/test/geocoder/googlegeocoder.js
+++ b/test/geocoder/googlegeocoder.js
@@ -175,6 +175,7 @@
                         "state"       : "Île-de-France",
                         "stateCode"   : "IDF",
                         "extra": {
+                          "confidence": 0,
                           "premise": null,
                           "subpremise": null,
                           "neighborhood": null,
@@ -293,7 +294,8 @@
                               "subpremise": null,
                               "neighborhood": null,
                               "establishment": null,
-                              "googlePlaceId": null
+                              "googlePlaceId": null,
+                              "confidence": 0
                             },
                             "formattedAddress": null
                         });
@@ -385,7 +387,7 @@
                 };
                 googleAdapter._signedRequest('https://maps.googleapis.com/maps/api/geocode/json', params);
                 expect(params.signature).to.equal('zLXE-mmcsjp2RobIXjMd9h3P-zM=');
-            });            
+            });
         });
 
     });

--- a/test/geocoder/opencagegeocoder.js
+++ b/test/geocoder/opencagegeocoder.js
@@ -131,7 +131,10 @@
                         "countryCode": "BR",
                         "zipcode": undefined,
                         "streetNumber": undefined,
-                        "county" : "RMSP"
+                        "county" : "RMSP",
+                        "extra" : {
+                          "confidence": 0.9
+                        }
                     });
 
                     results.raw.should.deep.equal({
@@ -247,7 +250,10 @@
                             "streetName": "Reichstagufer",
                             "streetNumber": 10,
                             "countryCode": "de",
-                            "county" : undefined
+                            "county" : undefined,
+                            "extra" : {
+                              "confidence": 0
+                            }
                         });
                         mock.verify();
                         done();


### PR DESCRIPTION
Just because I get a result doesn't mean it's right. For example, I may try to geocode a house address & only get the lat lng of a city. Ideally, if a service isn't accurate enough, I could retry it with another service (that's why your package is great).

That's what `confidence` is for. Within the extras object (for google, openmapquest, opencage, and geocodio) there's a confidence score from 0 to 1 (This is subjectively normalized based on my experience with each, although I tried to document as much as I could). A 1 means rooftop, .9 means interpolated, .8 means street, .7 means neighborhood-ish, etc. I've never used the other services, but could add confidence to those as well if desired.

Additionally, I added a module for geocod.io, which is a great source for TIGER data in the US. 