### PR TITLE
handled an error with http response.

### DIFF
--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -42,7 +42,8 @@ HttpAdapter.prototype.get = function(url, params, callback) {
                 return callback(new Error('Response status code is ' + response.statusCode), null);
             }
 
-            if (contentType.indexOf('application/json') >= 0) {
+            if (contentType !== undefined &&
+                contentType.indexOf('application/json') >= 0) {
                 callback(false, JSON.parse(str));
             } else {
                 callback(false, str);


### PR DESCRIPTION
When content-type were not present in http header an uncaught exception
were thrown.

This fixes https://github.com/nchaulet/node-geocoder/issues/107