### PR TITLE
GoogleGeocode - Exclude partial matches

### DIFF
--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -6,10 +6,10 @@ var crypto = require('crypto'),
 /**
  * Constructor
  * @param <object> httpAdapter Http Adapter
- * @param <object> options     Options (language, clientId, apiKey, region)
+ * @param <object> options     Options (language, clientId, apiKey, region, excludePartialMatches)
  */
 var GoogleGeocoder = function GoogleGeocoder(httpAdapter, options) {
-  this.options = ['language', 'apiKey', 'clientId', 'region'];
+  this.options = ['language', 'apiKey', 'clientId', 'region', 'excludePartialMatches'];
 
   GoogleGeocoder.super_.call(this, httpAdapter, options);
 
@@ -75,7 +75,14 @@ GoogleGeocoder.prototype._geocode = function (value, callback) {
       }
 
       for (var i = 0; i < result.results.length; i++) {
-        results.push(_this._formatResult(result.results[i]));
+
+        var currentResult = result.results[i];
+
+        if (params.excludePartialMatches && params.excludePartialMatches === true && typeof currentResult.partial_match !== "undefined" && currentResult.partial_match === true) {
+          continue;
+        }
+
+        results.push(_this._formatResult(currentResult));
       }
 
       results.raw = result;
@@ -105,7 +112,15 @@ GoogleGeocoder.prototype._prepareQueryString = function () {
     params.key = this.options.apiKey;
   }
 
+  //params.excludePartialMatches = (typeof this.options.excludePartialMatches !== "undefined" && this.options.excludePartialMatches === true);
+
+  if (this.options.excludePartialMatches && this.options.excludePartialMatches === true) {
+    params.excludePartialMatches = true;
+  }
+
+
   return params;
+
 };
 
 GoogleGeocoder.prototype._signedRequest = function (endpoint, params) {

--- a/test/geocoder/googlegeocoder.js
+++ b/test/geocoder/googlegeocoder.js
@@ -41,6 +41,7 @@
         });
 
         describe('#geocode' , function() {
+
             it('Should not accept IPv4', function() {
 
                 var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
@@ -234,6 +235,188 @@
 
                 googleAdapter.geocode('1 champs élysées Paris', function(err, results) {
                     err.message.should.to.equal("Status is INVALID_REQUEST.");
+                    mock.verify();
+                    done();
+                });
+            });
+
+            it('Should exclude partial match geocoded address if excludePartialMatches option is set to true', function(done) {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+
+                mock.expects('get').once().callsArgWith(2, false, { status: "OK", results: [{
+                        geometry: {location : {
+                            lat: 37.386,
+                            lng: -122.0838
+                        }},
+                        address_components: [
+                            {types: ['country'], long_name: 'France', short_name: 'Fr' },
+                            {types: ['locality'], long_name: 'Paris' },
+                            {types: ['postal_code'], long_name: '75008' },
+                            {types: ['route'], long_name: 'Champs-Élysées' },
+                            {types: ['street_number'], long_name: '1' },
+                            {types: ['administrative_area_level_1'], long_name: 'Île-de-France', short_name: 'IDF'}
+                        ],
+                        country_code: 'US',
+                        country_name: 'United States',
+                        locality: 'Mountain View',
+                        partial_match: true
+                    }]}
+                );
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter, { excludePartialMatches: true});
+
+                googleAdapter.geocode('1 champs élysées Paris', function(err, results) {
+                    err.should.to.equal(false);
+                    results.length.should.eql(0);
+
+                    mock.verify();
+                    done();
+                });
+            });
+
+            it('Should include partial match geocoded address if excludePartialMatches option is set to false', function(done) {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, { status: "OK", results: [{
+                        geometry: {location : {
+                            lat: 37.386,
+                            lng: -122.0838
+                        }},
+                        address_components: [
+                            {types: ['country'], long_name: 'France', short_name: 'Fr' },
+                            {types: ['locality'], long_name: 'Paris' },
+                            {types: ['postal_code'], long_name: '75008' },
+                            {types: ['route'], long_name: 'Champs-Élysées' },
+                            {types: ['street_number'], long_name: '1' },
+                            {types: ['administrative_area_level_1'], long_name: 'Île-de-France', short_name: 'IDF'}
+                        ],
+                        country_code: 'US',
+                        country_name: 'United States',
+                        locality: 'Mountain View',
+                        partial_match: true
+                    }]}
+                );
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter, { excludePartialMatches: false});
+
+                googleAdapter.geocode('1 champs élysées Paris', function(err, results) {
+                    err.should.to.equal(false);
+                    results[0].should.to.deep.equal({
+                        "latitude"    : 37.386,
+                        "longitude"   : -122.0838,
+                        "country"     : "France",
+                        "city"        : "Paris",
+                        "zipcode"     : "75008",
+                        "streetName"  : "Champs-Élysées",
+                        "streetNumber": "1",
+                        "countryCode" : "Fr",
+                        "administrativeLevels": {
+                            "level1long": "Île-de-France",
+                            "level1short": "IDF"
+                        },
+                        "extra": {
+                            "confidence": 0,
+                            "premise": null,
+                            "subpremise": null,
+                            "neighborhood": null,
+                            "establishment": null,
+                            "googlePlaceId": null
+                        },
+                        "formattedAddress": null
+                    });
+
+                    results.raw.should.deep.equal({ status: "OK", results: [{
+                        geometry: {location : {
+                            lat: 37.386,
+                            lng: -122.0838
+                        }},
+                        address_components: [
+                            {types: ['country'], long_name: 'France', short_name: 'Fr' },
+                            {types: ['locality'], long_name: 'Paris' },
+                            {types: ['postal_code'], long_name: '75008' },
+                            {types: ['route'], long_name: 'Champs-Élysées' },
+                            {types: ['street_number'], long_name: '1' },
+                            {types: ['administrative_area_level_1'], long_name: 'Île-de-France', short_name: 'IDF'}
+                        ],
+                        country_code: 'US',
+                        country_name: 'United States',
+                        locality: 'Mountain View',
+                        partial_match: true
+                    }]});
+
+                    mock.verify();
+                    done();
+                });
+            });
+
+            it('Should include partial match geocoded address if excludePartialMatches option is not set', function(done) {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, { status: "OK", results: [{
+                        geometry: {location : {
+                            lat: 37.386,
+                            lng: -122.0838
+                        }},
+                        address_components: [
+                            {types: ['country'], long_name: 'France', short_name: 'Fr' },
+                            {types: ['locality'], long_name: 'Paris' },
+                            {types: ['postal_code'], long_name: '75008' },
+                            {types: ['route'], long_name: 'Champs-Élysées' },
+                            {types: ['street_number'], long_name: '1' },
+                            {types: ['administrative_area_level_1'], long_name: 'Île-de-France', short_name: 'IDF'}
+                        ],
+                        country_code: 'US',
+                        country_name: 'United States',
+                        locality: 'Mountain View',
+                        partial_match: true
+                    }]}
+                );
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
+
+                googleAdapter.geocode('1 champs élysées Paris', function(err, results) {
+                    err.should.to.equal(false);
+                    results[0].should.to.deep.equal({
+                        "latitude"    : 37.386,
+                        "longitude"   : -122.0838,
+                        "country"     : "France",
+                        "city"        : "Paris",
+                        "zipcode"     : "75008",
+                        "streetName"  : "Champs-Élysées",
+                        "streetNumber": "1",
+                        "countryCode" : "Fr",
+                        "administrativeLevels": {
+                            "level1long": "Île-de-France",
+                            "level1short": "IDF"
+                        },
+                        "extra": {
+                            "confidence": 0,
+                            "premise": null,
+                            "subpremise": null,
+                            "neighborhood": null,
+                            "establishment": null,
+                            "googlePlaceId": null
+                        },
+                        "formattedAddress": null
+                    });
+
+                    results.raw.should.deep.equal({ status: "OK", results: [{
+                        geometry: {location : {
+                            lat: 37.386,
+                            lng: -122.0838
+                        }},
+                        address_components: [
+                            {types: ['country'], long_name: 'France', short_name: 'Fr' },
+                            {types: ['locality'], long_name: 'Paris' },
+                            {types: ['postal_code'], long_name: '75008' },
+                            {types: ['route'], long_name: 'Champs-Élysées' },
+                            {types: ['street_number'], long_name: '1' },
+                            {types: ['administrative_area_level_1'], long_name: 'Île-de-France', short_name: 'IDF'}
+                        ],
+                        country_code: 'US',
+                        country_name: 'United States',
+                        locality: 'Mountain View',
+                        partial_match: true
+                    }]});
+
                     mock.verify();
                     done();
                 });


### PR DESCRIPTION
The google api can try and be clever and return partial "fuzzy" matches.

In a project I am currently working on we didn't require these.  I was able to filter them out by checking the results.raw.results object.  

I thought it may be useful to add 'excludePartialMatches' option to allow these to be filtered out. 