### PR TITLE
Add X-RateLimit-* Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ geocoder.geocode('29 champs elysée paris')
        level2short: '75' }
 }]
 
-## Advanced usage (only google and here providers)
+// Advanced usage (only google and here providers)
 geocoder.geocode({address: '29 champs elysée', country: 'France', zipcode: '75008'}, function(err, res) {
     console.log(res);
 });
@@ -81,6 +81,13 @@ geocoder.batchGeocode(['13 rue sainte catherine', 'another adress'], function (r
     // Return an array of type {error: false, value: []}
     console.log(results) ;
 });
+
+// Check X-RateLimit-* Headers (Limit, Remaining, Reset)
+// - returns null if header was not given in response
+
+console.log(geocoder.rateLimit.limit)
+console.log(geocoder.rateLimit.remaining)
+console.log(geocoder.rateLimit.reset)
 
 ```
 

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -158,6 +158,7 @@ var GeocoderFactory = {
     }
 
     var geocoder = new Geocoder(geocoderAdapter, formatter);
+    geocoder.rateLimit = httpAdapter.rateLimit;
 
     return geocoder;
   }

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -9,11 +9,18 @@ var HttpAdapter = function(http) {
 
   this.url = require('url');
   this.http = http;
-  this.rateLimit = {
-    limit: null,
-    remaining: null,
-    reset: null
-  };
+};
+
+/**
+* X-RateLimit-* Headers
+* @attribute limit     X-RateLimit-Limit     - the total number of transactions that your account is limited to over a 24 hour period
+* @attribute remaining X-RateLimit-Remaining - the number of transactions remaining in the current 24 hour period
+* @attribute reset     X-RateLimit-Reset     - the date and time, in UNIX format, at which your transaction count will reset
+*/
+HttpAdapter.prototype.rateLimit = {
+  limit: null,
+  remaining: null,
+  reset: null
 };
 
 /**

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -33,20 +33,19 @@ HttpAdapter.prototype.get = function(url, params, callback) {
     }
 
   };
-  var self = this;
 
   this.http.request(options, function(response) {
     var str = '';
     var contentType = response.headers['content-type'];
 
     if (response.headers['X-RateLimit-Limit']) {
-      self.rateLimit.limit = response.headers['X-RateLimit-Limit'];
+      this.rateLimit.limit = response.headers['X-RateLimit-Limit'];
     }
     if (response.headers['X-RateLimit-Remaining']) {
-      self.rateLimit.remaining = response.headers['X-RateLimit-Remaining'];
+      this.rateLimit.remaining = response.headers['X-RateLimit-Remaining'];
     }
     if (response.headers['X-RateLimit-Reset']) {
-      self.rateLimit.reset = response.headers['X-RateLimit-Reset'];
+      this.rateLimit.reset = response.headers['X-RateLimit-Reset'];
     }
 
     response.on('data', function(chunk) {
@@ -67,11 +66,11 @@ HttpAdapter.prototype.get = function(url, params, callback) {
       }
 
     });
+  }.bind(this))
+  .on('error', function(err) {
+    callback(new HttpError(err.message), null);
   })
-    .on('error', function(err) {
-      callback(new HttpError(err.message), null);
-    })
-    .end();
+  .end();
 };
 
 HttpAdapter.prototype.supportsHttps = function() {

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -39,12 +39,15 @@ HttpAdapter.prototype.get = function(url, params, callback) {
     var str = '';
     var contentType = response.headers['content-type'];
 
-    if (response.headers['X-RateLimit-Limit'])
+    if (response.headers['X-RateLimit-Limit']) {
       self.rateLimit.limit = response.headers['X-RateLimit-Limit'];
-    if (response.headers['X-RateLimit-Remaining'])
+    }
+    if (response.headers['X-RateLimit-Remaining']) {
       self.rateLimit.remaining = response.headers['X-RateLimit-Remaining'];
-    if (response.headers['X-RateLimit-Reset'])
+    }
+    if (response.headers['X-RateLimit-Reset']) {
       self.rateLimit.reset = response.headers['X-RateLimit-Reset'];
+    }
 
     response.on('data', function(chunk) {
       str += chunk;

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -9,6 +9,11 @@ var HttpAdapter = function(http) {
 
   this.url = require('url');
   this.http = http;
+  this.rateLimit = {
+    limit: null,
+    remaining: null,
+    reset: null
+  };
 };
 
 /**
@@ -28,10 +33,19 @@ HttpAdapter.prototype.get = function(url, params, callback) {
     }
 
   };
+  var self = this;
 
   this.http.request(options, function(response) {
     var str = '';
     var contentType = response.headers['content-type'];
+
+    if (response.headers['X-RateLimit-Limit'])
+      self.rateLimit.limit = response.headers['X-RateLimit-Limit'];
+    if (response.headers['X-RateLimit-Remaining'])
+      self.rateLimit.remaining = response.headers['X-RateLimit-Remaining'];
+    if (response.headers['X-RateLimit-Reset'])
+      self.rateLimit.reset = response.headers['X-RateLimit-Reset'];
+
     response.on('data', function(chunk) {
       str += chunk;
     });


### PR DESCRIPTION
Hey there,
for some this headers could be essential as for me.

**Rate Limit Headers**
- X-RateLimit-Limit - the total number of transactions that your account is limited to over a 24 hour period
- X-RateLimit-Remaining - the number of transactions remaining in the current 24 hour period
- X-RateLimit-Reset - the date and time, in UNIX format, at which your transaction count will reset

At least one provider implemented this. I would guess others too.
http://geocoder.opencagedata.com/api.html#rate-limiting

I will test this the next couple of day but maybe someone is able to test it faster?
