### PR TITLE
Added required api Key to Nominatimmapquestgeocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ geocoder.batchGeocode(['13 rue sainte catherine', 'another adress'], function (r
 * `openmapquest` : Open MapQuestGeocoder (based on OpenStreetMapGeocoder). Supports address geocoding and reverse geocoding. Needs an apiKey
 * `agol` : ArcGis Online Geocoding service. Supports geocoding and reverse. Requires a client_id & client_secret and 'https' http adapter
 * `tomtom`: TomTomGeocoder. Supports address geocoding. You need to specify `extra.apiKey`
-* `nominatimmapquest`: Same geocoder as `openstreetmap`, but queries the MapQuest servers.
+* `nominatimmapquest`: Same geocoder as `openstreetmap`, but queries the MapQuest servers. You need to specify `extra.apiKey`
 * `opencage`: OpenCage Geocoder. Uses multiple open sources. Supports address and reverse geocoding. You need to specify `extra.apiKey`
 * `smartyStreet`: Smarty street geocoder (US only), you need to specify `extra.auth_id` and `extra.auth_token`
 * `geocodio`: Geocodio, Supports address geocoding and reverse geocoding (US only)

--- a/lib/geocoder/nominatimmapquestgeocoder.js
+++ b/lib/geocoder/nominatimmapquestgeocoder.js
@@ -6,12 +6,18 @@ var util                  = require('util'),
  */
 var NominatimMapquestGeocoder = function NominatimMapquestGeocoder(httpAdapter, options) {
     NominatimMapquestGeocoder.super_.call(this, httpAdapter, options);
+
+    if (!this.options.apiKey || this.options.apiKey == 'undefined') {
+      throw new Error(this.constructor.name + ' needs an apiKey');
+    }
+    this.options.key = this.options.apiKey;
+    delete this.options.apiKey;
 };
 
 util.inherits(NominatimMapquestGeocoder, OpenStreetMapGeocoder);
 
-NominatimMapquestGeocoder.prototype._endpoint = 'http://open.mapquestapi.com/nominatim/v1';
 NominatimMapquestGeocoder.prototype._endpoint = 'http://open.mapquestapi.com/nominatim/v1/search';
+NominatimMapquestGeocoder.prototype._endpoint_reverse = 'http://open.mapquestapi.com/nominatim/v1/reverse';
 
 
 module.exports = NominatimMapquestGeocoder;

--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -5,7 +5,7 @@ var util             = require('util'),
  * Constructor
  */
 var OpenStreetMapGeocoder = function OpenStreetMapGeocoder(httpAdapter, options) {
-    this.options = ['language','email'];
+    this.options = ['language','email','apiKey'];
 
     OpenStreetMapGeocoder.super_.call(this, httpAdapter, options);
 };

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -93,7 +93,7 @@ var GeocoderFactory = {
     if (geocoderName === 'nominatimmapquest') {
       var NominatimMapquestGeocoder = require('./geocoder/nominatimmapquestgeocoder.js');
 
-      return new NominatimMapquestGeocoder(adapter, {language: extra.language});
+      return new NominatimMapquestGeocoder(adapter, {language: extra.language, apiKey: extra.apiKey});
     }
     if (geocoderName === 'tomtom') {
       var TomTomGeocoder = require('./geocoder/tomtomgeocoder.js');

--- a/test/geocoder/nominatimmapquestgeocoder.js
+++ b/test/geocoder/nominatimmapquestgeocoder.js
@@ -19,9 +19,14 @@
                 expect(function() {new NominatimMapquestGeocoder();}).to.throw(Error, 'NominatimMapquestGeocoder need an httpAdapter');
             });
 
+            it('an apiKey must be set', function() {
+
+                expect(function() {new NominatimMapquestGeocoder(mockedHttpAdapter);}).to.throw(Error, 'NominatimMapquestGeocoder needs an apiKey');
+            });
+
             it('Should be an instance of NominatimMapquestGeocoder', function() {
 
-                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter);
+                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter, {apiKey: 'API_KEY'});
 
                 nmAdapter.should.be.instanceof(NominatimMapquestGeocoder);
             });
@@ -32,7 +37,7 @@
 
             it('Should not accept IPv4', function() {
 
-                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter);
+                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter, {apiKey: 'API_KEY'});
 
                 expect(function() {
                         nmAdapter.geocode('127.0.0.1');
@@ -42,7 +47,7 @@
 
             it('Should not accept IPv6', function() {
 
-                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter);
+                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter, {apiKey: 'API_KEY'});
 
                 expect(function() {
                         nmAdapter.geocode('2001:0db8:0000:85a3:0000:0000:ac1f:8001');
@@ -53,9 +58,12 @@
             it('Should call httpAdapter get method', function() {
 
                 var mock = sinon.mock(mockedHttpAdapter);
-                mock.expects('get').once().returns({then: function() {}});
+                mock.expects('get').once()
+                .withArgs("http://open.mapquestapi.com/nominatim/v1/search",
+                { key: 'API_KEY', addressdetails: 1, format: "json", q: "1 champs élysée Paris" })
+                .returns({then: function() {}});
 
-                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter);
+                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter, {apiKey: 'API_KEY'});
 
                 nmAdapter.geocode('1 champs élysée Paris');
 
@@ -92,7 +100,7 @@
                     }]
                 );
 
-                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter);
+                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter, {apiKey: 'API_KEY'});
 
                 nmAdapter.geocode('135 pilkington avenue, birmingham', function(err, results) {
                     mock.verify();
@@ -120,7 +128,10 @@
         describe('#reverse' , function() {
             it('Should return geocoded address', function(done) {
                 var mock = sinon.mock(mockedHttpAdapter);
-                mock.expects('get').once().callsArgWith(2, false, {
+                mock.expects('get').once()
+                .withArgs("http://open.mapquestapi.com/nominatim/v1/reverse",
+                { key: 'API_KEY', addressdetails: 1, format: "json", lat:40.714232, lon:-73.9612889 })
+                .callsArgWith(2, false, {
                         "place_id": "149160357",
                         "licence": "Data \u00a9 OpenStreetMap contributors, ODbL 1.0. http:\/\/www.openstreetmap.org\/copyright",
                         "osm_type": "way",
@@ -141,7 +152,7 @@
                         }
                     }
                 );
-                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter);
+                var nmAdapter = new NominatimMapquestGeocoder(mockedHttpAdapter, {apiKey: 'API_KEY'});
                 nmAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                     mock.verify();
                     err.should.to.equal(false);


### PR DESCRIPTION
All Nominatim and Xapi requests require a key starting September 15, 2015.