### PR TITLE
Fix YandexGeocoder test name

### DIFF
--- a/test/geocoder/yandexgeocoder.js
+++ b/test/geocoder/yandexgeocoder.js
@@ -9,7 +9,7 @@ var mockedHttpAdapter = {
     get: function() {}
 };
 
-describe('OpenCageGeocoder', function() {
+describe('YandexGeocoder', function() {
 
   describe('#constructor' , function() {
     it('an http adapter must be set', function() {


### PR DESCRIPTION
Seems this was left over from copying from OpenCageGeocoder.