### PR TITLE
Add Teleport geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ var geocoder = require('node-geocoder')(geocoderProvider, httpAdapter, extra);
 * `smartyStreet`: Smarty street geocoder (US only), you need to specify `extra.auth_id` and `extra.auth_token`
 * `geocodio`: Geocodio, Supports address geocoding and reverse geocoding (US only)
 * `yandex`: Yandex support address geocoding, you can use `extra.language` to specify language
+* `teleport`: Teleport supports city and urban area forward and reverse geocoding; for more information, see [Teleport API documentation](https://developers.teleport.org/api/)
 
 ## Http adapter
 

--- a/lib/geocoder/teleportgeocoder.js
+++ b/lib/geocoder/teleportgeocoder.js
@@ -1,0 +1,138 @@
+var util = require('util');
+var AbstractGeocoder = require('./abstractgeocoder');
+
+/**
+ * Constructor
+ */
+var TeleportGeocoder = function TeleportGeocoder(httpAdapter, options) {
+    TeleportGeocoder.super_.call(this, httpAdapter, options);
+
+    var base = 'https://api.teleport.org/api';
+    this._cities_endpoint = base + '/cities/';
+    this._locations_endpoint = base + '/locations/';
+};
+
+util.inherits(TeleportGeocoder, AbstractGeocoder);
+
+function getEmbeddedPath(parent, path) {
+    var elements = path.split('/');
+    for ( var i in elements) {
+        var element = elements[i];
+        var embedded = parent._embedded;
+        if (!embedded) {
+            return undefined;
+        }
+        var child = embedded[element];
+        if (!child) {
+            return undefined;
+        }
+        parent = child;
+    }
+    return parent;
+}
+
+/**
+ * Geocode
+ *
+ * @param <string>    value     Value to geocode (Address)
+ * @param <function>  callback  Callback method
+ */
+TeleportGeocoder.prototype._geocode = function(value, callback) {
+    var _this = this;
+
+    var params = {};
+    params.search = value;
+    params.embed = 'city:search-results/city:item/{city:country,city:admin1_division,city:urban_area}';
+
+    this.httpAdapter.get(this._cities_endpoint, params, function(err, result) {
+
+        if (err) {
+            return callback(err);
+        } else {
+            var results = [];
+
+            if (result) {
+                var searchResults = getEmbeddedPath(result, 'city:search-results') || [];
+                for (var i in searchResults) {
+                    var confidence = (25 - i) / 25.0 * 10;
+                    results.push(_this._formatResult(searchResults[i], 'city:item', confidence));
+                }
+            }
+
+            results.raw = result;
+            callback(false, results);
+        }
+
+    });
+
+};
+
+TeleportGeocoder.prototype._formatResult = function(result, cityRelationName, confidence) {
+    var city = getEmbeddedPath(result, cityRelationName);
+    var admin1 = getEmbeddedPath(city, 'city:admin1_division') || {};
+    var country = getEmbeddedPath(city, 'city:country') || {};
+    var urban_area = getEmbeddedPath(city, 'city:urban_area') || {};
+    var urban_area_links = urban_area._links || {};
+    var extra = {
+        confidence: confidence,
+        urban_area: urban_area.name,
+        urban_area_api_url: (urban_area_links.self || {}).href,
+        urban_area_web_url: urban_area.teleport_city_url
+    };
+    if (result.distance_km) {
+        extra.distance_km = result.distance_km;
+    }
+    if (result.matching_full_name) {
+        extra.matching_full_name = result.matching_full_name;
+    }
+
+    return {
+        'latitude': city.location.latlon.latitude,
+        'longitude': city.location.latlon.longitude,
+        'city': city.name,
+        'country': country.name,
+        'countryCode': country.iso_alpha2,
+        'state': admin1.name,
+        'stateCode': admin1.geonames_admin1_code,
+        'extra': extra
+    };
+};
+
+/**
+ * Reverse geocoding
+ *
+ * @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
+ * @param <function> callback          Callback method
+ */
+TeleportGeocoder.prototype._reverse = function(query, callback) {
+    var lat = query.lat;
+    var lng = query.lon;
+    var suffix = lat + ',' + lng;
+
+    var _this = this;
+
+    var params = {};
+    params.embed = 'location:nearest-cities/location:nearest-city/{city:country,city:admin1_division,city:urban_area}';
+
+    this.httpAdapter.get(this._locations_endpoint + suffix, params, function(err, result) {
+        if (err) {
+            throw err;
+        } else {
+            var results = [];
+
+            if (result) {
+                var searchResults = getEmbeddedPath(result, 'location:nearest-cities') || [];
+                for ( var i in searchResults) {
+                    var searchResult = searchResults[i];
+                    var confidence = Math.max(0, 25 - searchResult.distance_km) / 25 * 10;
+                    results.push(_this._formatResult(searchResult, 'location:nearest-city', confidence));
+                }
+            }
+
+            results.raw = result;
+            callback(false, results);
+        }
+    });
+};
+
+module.exports = TeleportGeocoder;

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -106,6 +106,12 @@ var GeocoderFactory = {
       return new SmartyStreets(adapter, extra.auth_id, extra.auth_token);
     }
 
+    if (geocoderName === 'teleport') {
+      var TeleportGeocoder = require('./geocoder/teleportgeocoder.js');
+
+      return new TeleportGeocoder(adapter, extra.apiKey, extra);
+    }
+
     throw new Error('No geocoder provider find for : ' + geocoderName);
   },
   /**

--- a/test/geocoder/teleportgeocoder.js
+++ b/test/geocoder/teleportgeocoder.js
@@ -1,0 +1,352 @@
+(function() {
+    var chai = require('chai');
+    var should = chai.should();
+    var expect = chai.expect;
+    var sinon = require('sinon');
+
+    var TeleportGeocoder = require('../../lib/geocoder/teleportgeocoder.js');
+
+    var mockedHttpAdapter = {
+        get: function() {}
+    };
+
+    describe('TeleportGeocoder', function() {
+
+        describe('#constructor', function() {
+
+            it('an http adapter must be set', function() {
+
+                expect(function() {
+                    new TeleportGeocoder();
+                }).to.Throw(Error, 'TeleportGeocoder need an httpAdapter');
+            });
+
+            it('Should be an instance of TeleportGeocoder', function() {
+
+                var tpAdapter = new TeleportGeocoder(mockedHttpAdapter);
+
+                tpAdapter.should.be.instanceOf(TeleportGeocoder);
+            });
+
+        });
+
+        describe('#geocode', function() {
+
+            it('Should not accept IPv4', function() {
+
+                var tpAdapter = new TeleportGeocoder(mockedHttpAdapter);
+
+                expect(function() {
+                    tpAdapter.geocode('127.0.0.1');
+                }).to.Throw(Error, 'TeleportGeocoder does not support geocoding IPv4');
+
+            });
+
+            it('Should not accept IPv6', function() {
+
+                var tpAdapter = new TeleportGeocoder(mockedHttpAdapter);
+
+                expect(function() {
+                    tpAdapter.geocode('2001:0db8:0000:85a3:0000:0000:ac1f:8001');
+                }).to.Throw(Error, 'TeleportGeocoder does not support geocoding IPv6');
+
+            });
+
+            it('Should call mockedHttpAdapter get method', function() {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().returns({then: function() {}});
+
+                var tpAdapter = new TeleportGeocoder(mockedHttpAdapter);
+                tpAdapter.geocode('New York, NY');
+
+                mock.verify();
+            });
+
+            it('Should return geocoded address', function(done) {
+                var response = {
+                    "_embedded": {
+                        "city:search-results": [{
+                            "_embedded": {
+                                "city:item": {
+                                    "_embedded": {
+                                        "city:admin1_division": {
+                                            "geonames_admin1_code": "CA",
+                                            "name": "California"
+                                        },
+                                        "city:country": {
+                                            "iso_alpha2": "US",
+                                            "name": "United States",
+                                        },
+                                        "city:urban_area": {
+                                            "_links": {
+                                                "self": {
+                                                    "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/"
+                                                },
+                                                "ua:images": {
+                                                    "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/images/"
+                                                },
+                                                "ua:scores": {
+                                                    "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/scores/"
+                                                }
+                                            },
+                                            "name": "San Francisco Bay Area",
+                                            "teleport_city_url": "https://my.teleport.org/public/cities/9q8yy/San_Francisco_Bay_Area/",
+                                            "ua_id": "9q8yy"
+                                        }
+                                    },
+                                    "location": {
+                                        "geohash": "9q9jh844v274h2gte8sk",
+                                        "latlon": {
+                                            "latitude": 37.44188,
+                                            "longitude": -122.14302
+                                        }
+                                    },
+                                    "name": "Palo Alto",
+                                    "population": 64403
+                                }
+                            },
+                            "_links": {
+                                "city:item": {
+                                    "href": "https://api.teleport.org/api/cities/geonameid:5380748/"
+                                }
+                            },
+                            "matching_full_name": "Palo Alto, California, United States"
+                        }]
+                    },
+                };
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, response);
+
+                var tpAdapter = new TeleportGeocoder(mockedHttpAdapter);
+
+                tpAdapter.geocode('Palo Alto, CA', function(err, results) {
+                    expect(err).to.equal(false);
+
+                    expect(results[0]).to.deep.equal({
+                        'latitude': 37.44188,
+                        'longitude': -122.14302,
+                        'city': 'Palo Alto',
+                        'country': 'United States',
+                        'countryCode': 'US',
+                        'state': 'California',
+                        'stateCode': 'CA',
+                        'extra': {
+                            'confidence': 10,
+                            'urban_area': 'San Francisco Bay Area',
+                            'urban_area_api_url': 'https://api.teleport.org/api/urban_areas/teleport:9q8yy/',
+                            'urban_area_web_url': 'https://my.teleport.org/public/cities/9q8yy/San_Francisco_Bay_Area/',
+                            'matching_full_name': 'Palo Alto, California, United States',
+                        },
+                    });
+
+                    expect(results.raw).to.deep.equal(response);
+
+                    mock.verify();
+                    done();
+                });
+            });
+
+        });
+
+        describe('#reverse', function() {
+            it('Should return geocoded address', function(done) {
+                var response = {
+                    "_embedded": {
+                        "location:nearest-cities": [{
+                            "_embedded": {
+                                "location:nearest-city": {
+                                    "_embedded": {
+                                        "city:admin1_division": {
+                                            "_links": {
+                                                "a1:cities": {
+                                                    "href": "https://api.teleport.org/api/countries/iso_alpha2:US/admin1_divisions/geonames:CA/cities/"
+                                                },
+                                                "a1:country": {
+                                                    "href": "https://api.teleport.org/api/countries/iso_alpha2:US/"
+                                                },
+                                                "self": {
+                                                    "href": "https://api.teleport.org/api/countries/iso_alpha2:US/admin1_divisions/geonames:CA/"
+                                                }
+                                            },
+                                            "geoname_id": 5332921,
+                                            "geonames_admin1_code": "CA",
+                                            "name": "California"
+                                        },
+                                        "city:country": {
+                                            "_links": {
+                                                "country:admin1_divisions": {
+                                                    "href": "https://api.teleport.org/api/countries/iso_alpha2:US/admin1_divisions/"
+                                                },
+                                                "self": {
+                                                    "href": "https://api.teleport.org/api/countries/iso_alpha2:US/"
+                                                }
+                                            },
+                                            "geoname_id": 6252001,
+                                            "iso_alpha2": "US",
+                                            "iso_alpha3": "USA",
+                                            "name": "United States",
+                                            "population": 310232863
+                                        },
+                                        "city:urban_area": {
+                                            "_links": {
+                                                "self": {
+                                                    "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/"
+                                                },
+                                                "ua:admin1-divisions": [{
+                                                    "href": "https://api.teleport.org/api/countries/iso_alpha2:US/admin1_divisions/geonames:CA/",
+                                                    "name": "California"
+                                                }],
+                                                "ua:countries": [{
+                                                    "href": "https://api.teleport.org/api/countries/iso_alpha2:US/",
+                                                    "name": "United States"
+                                                }],
+                                                "ua:images": {
+                                                    "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/images/"
+                                                },
+                                                "ua:primary-cities": [{
+                                                    "href": "https://api.teleport.org/api/cities/geonameid:5392171/",
+                                                    "name": "San Jose"
+                                                }, {
+                                                    "href": "https://api.teleport.org/api/cities/geonameid:5391959/",
+                                                    "name": "San Francisco"
+                                                }, {
+                                                    "href": "https://api.teleport.org/api/cities/geonameid:5389489/",
+                                                    "name": "Sacramento"
+                                                }, {
+                                                    "href": "https://api.teleport.org/api/cities/geonameid:5378538/",
+                                                    "name": "Oakland"
+                                                }],
+                                                "ua:scores": {
+                                                    "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/scores/"
+                                                }
+                                            },
+                                            "name": "San Francisco Bay Area",
+                                            "teleport_city_url": "https://my.teleport.org/public/cities/9q8yy/San_Francisco_Bay_Area/",
+                                            "ua_id": "9q8yy"
+                                        }
+                                    },
+                                    "_links": {
+                                        "city:admin1_division": {
+                                            "href": "https://api.teleport.org/api/countries/iso_alpha2:US/admin1_divisions/geonames:CA/",
+                                            "name": "California"
+                                        },
+                                        "city:alternate-names": {
+                                            "href": "https://api.teleport.org/api/cities/geonameid:5380748/alternate_names/"
+                                        },
+                                        "city:country": {
+                                            "href": "https://api.teleport.org/api/countries/iso_alpha2:US/",
+                                            "name": "United States"
+                                        },
+                                        "city:timezone": {
+                                            "href": "https://api.teleport.org/api/timezones/iana:America%2FLos_Angeles/",
+                                            "name": "America/Los_Angeles"
+                                        },
+                                        "city:urban_area": {
+                                            "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/",
+                                            "name": "San Francisco Bay Area"
+                                        },
+                                        "self": {
+                                            "href": "https://api.teleport.org/api/cities/geonameid:5380748/"
+                                        }
+                                    },
+                                    "full_name": "Palo Alto, California, United States",
+                                    "geoname_id": 5380748,
+                                    "location": {
+                                        "geohash": "9q9jh844v274h2gte8sk",
+                                        "latlon": {
+                                            "latitude": 37.44188,
+                                            "longitude": -122.14302
+                                        }
+                                    },
+                                    "name": "Palo Alto",
+                                    "population": 64403
+                                }
+                            },
+                            "_links": {
+                                "location:nearest-city": {
+                                    "href": "https://api.teleport.org/api/cities/geonameid:5380748/",
+                                    "name": "Palo Alto"
+                                }
+                            },
+                            "distance_km": 1.9742334
+                        }],
+                        "location:nearest-urban-areas": [{
+                            "_links": {
+                                "location:nearest-urban-area": {
+                                    "href": "https://api.teleport.org/api/urban_areas/teleport:9q8yy/",
+                                    "name": "San Francisco Bay Area"
+                                }
+                            },
+                            "distance_km": 0
+                        }]
+                    },
+                    "_links": {
+                        "curies": [{
+                            "href": "https://developers.teleport.org/api/",
+                            "name": "location"
+                        }, {
+                            "href": "https://developers.teleport.org/api/",
+                            "name": "city"
+                        }, {
+                            "href": "https://developers.teleport.org/api/",
+                            "name": "ua"
+                        }, {
+                            "href": "https://developers.teleport.org/api/",
+                            "name": "country"
+                        }, {
+                            "href": "https://developers.teleport.org/api/",
+                            "name": "a1"
+                        }, {
+                            "href": "https://developers.teleport.org/api/",
+                            "name": "tz"
+                        }],
+                        "self": {
+                            "href": "https://api.teleport.org/api/locations/37.455056,-122.158009/"
+                        }
+                    },
+                    "coordinates": {
+                        "geohash": "",
+                        "latlon": {
+                            "latitude": 37.455056,
+                            "longitude": -122.158009
+                        }
+                    }
+                };
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, response);
+                
+                var tpAdapter = new TeleportGeocoder(mockedHttpAdapter);
+                tpAdapter.reverse({
+                    lat: 37.455056,
+                    lon: -122.158009,
+                }, function(err, results) {
+                    expect(err).to.equal(false);
+                    expect(results[0]).to.deep.equal({
+                        'latitude': 37.44188,
+                        'longitude': -122.14302,
+                        'city': 'Palo Alto',
+                        'country': 'United States',
+                        'countryCode': 'US',
+                        'state': 'California',
+                        'stateCode': 'CA',
+                        'extra': {
+                            'confidence': 9.21030664,
+                            'urban_area': 'San Francisco Bay Area',
+                            'urban_area_api_url': 'https://api.teleport.org/api/urban_areas/teleport:9q8yy/',
+                            'urban_area_web_url': 'https://my.teleport.org/public/cities/9q8yy/San_Francisco_Bay_Area/',
+                            'distance_km': 1.9742334,
+                        },
+                    });
+
+                    expect(results.raw).to.deep.equal(response);
+
+                    mock.verify();
+                    done();
+                });
+            });
+        });
+    });
+})();


### PR DESCRIPTION
I implemented support for forward and reverse city geocoding using Teleport APIs.

Teleport geocoding APIs are based on GeoNames cities1000 (i.e. cities with population > 1000) dataset, but with different logic for searching for cities by name, administrative division and country.

Disclaimer: I work for @teleport

Let me know if there's anything that needs to be changed in order to merge.