### PR TITLE
adds http(s) request timeout support

### DIFF
--- a/lib/error/httperror.js
+++ b/lib/error/httperror.js
@@ -1,11 +1,17 @@
 var util = require('util');
 
-var HttpError = function(message) {
+var HttpError = function(message, options) {
     Error.call(this);
     Error.captureStackTrace(this, this.constructor);
 
     this.name = 'HttpError';
     this.message = message;
+
+    options = options || {};
+
+    for(var k in options) {
+      this[k] = this[k] || options[k];
+    }
 };
 
 util.inherits(HttpError, Error);

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -11,18 +11,18 @@ var GeocoderFactory = {
   * @param  <string> adapterName adapter name
   * @return <object>
   */
-  _getHttpAdapter: function(adapterName) {
+  _getHttpAdapter: function(adapterName, options) {
 
     if (adapterName === 'http') {
       var HttpAdapter = require('./httpadapter/httpadapter.js');
 
-      return new HttpAdapter();
+      return new HttpAdapter(null, options);
     }
 
     if (adapterName === 'https') {
       var HttpsAdapter = require('./httpadapter/httpsadapter.js');
 
-      return new HttpsAdapter();
+      return new HttpsAdapter(null, options);
     }
   },
   /**
@@ -150,7 +150,7 @@ var GeocoderFactory = {
     }
 
     if (Helper.isString(httpAdapter)) {
-      httpAdapter = this._getHttpAdapter(httpAdapter);
+      httpAdapter = this._getHttpAdapter(httpAdapter, extra);
     }
 
     if (Helper.isString(geocoderAdapter)) {

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -45,7 +45,7 @@ HttpAdapter.prototype.get = function(url, params, callback) {
     }
   }
 
-  this.http.request(options, function(response) {
+  var request = this.http.request(options, function(response) {
     var str = '';
     var contentType = response.headers['content-type'];
     response.on('data', function(chunk) {
@@ -54,7 +54,6 @@ HttpAdapter.prototype.get = function(url, params, callback) {
 
     //the whole response has been recieved, so we just print it out here
     response.on('end', function() {
-
       if (response.statusCode !== 200) {
         return callback(new Error('Response status code is ' + response.statusCode), null);
       }
@@ -66,11 +65,44 @@ HttpAdapter.prototype.get = function(url, params, callback) {
       }
 
     });
-  })
-    .on('error', function(err) {
-      callback(new HttpError(err.message), null);
-    })
-    .end();
+  });
+
+  var timedout = false;
+
+  var onError = function(err) {
+    if(err.code === 'ETIMEDOUT') {
+      timedout = true;
+      request.abort();
+    }
+
+    // aborted request can cause ECONNRESET, ignore if this was due to a timeout
+    if(!(err.code === 'ECONNRESET' && timedout)) {
+      var error = err instanceof HttpError ? err : new HttpError(err.message, {
+        code: err.code
+      });
+      callback(error, null);
+    }
+  };
+
+  request.on('error', onError);
+
+  if(typeof options.timeout !== 'undefined') {
+    request.on('socket', function(socket) {
+      socket.setTimeout(options.timeout);
+
+      socket.on('timeout', function() {
+        // faux node timeout error
+        // can't seem to pull out socket remoteAddress/Port
+        onError(new HttpError('connect ETIMEDOUT', {
+          code: 'ETIMEDOUT',
+          errno: 'ETIMEDOUT',
+          syscall: 'connect'
+        }));
+      });
+    });
+  }
+
+  request.end();
 };
 
 HttpAdapter.prototype.supportsHttps = function() {

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -67,40 +67,26 @@ HttpAdapter.prototype.get = function(url, params, callback) {
     });
   });
 
-  var timedout = false;
+  if(typeof options.timeout !== 'undefined') {
+    request.setTimeout(options.timeout);
+  }
 
   var onError = function(err) {
-    if(err.code === 'ETIMEDOUT') {
-      timedout = true;
-      request.abort();
-    }
-
-    // aborted request can cause ECONNRESET, ignore if this was due to a timeout
-    if(!(err.code === 'ECONNRESET' && timedout)) {
-      var error = err instanceof HttpError ? err : new HttpError(err.message, {
-        code: err.code
-      });
-      callback(error, null);
-    }
+    var error = err instanceof HttpError ? err : new HttpError(err.message, {
+      code: err.code
+    });
+    callback(error, null);
   };
 
   request.on('error', onError);
 
-  if(typeof options.timeout !== 'undefined') {
-    request.on('socket', function(socket) {
-      socket.setTimeout(options.timeout);
-
-      socket.on('timeout', function() {
-        // faux node timeout error
-        // can't seem to pull out socket remoteAddress/Port
-        onError(new HttpError('connect ETIMEDOUT', {
-          code: 'ETIMEDOUT',
-          errno: 'ETIMEDOUT',
-          syscall: 'connect'
-        }));
-      });
-    });
-  }
+  request.on('timeout', function() {
+    onError(new HttpError('connect ETIMEDOUT', {
+      code: 'ETIMEDOUT',
+      errno: 'ETIMEDOUT',
+      syscall: 'connect'
+    }));
+  });
 
   request.end();
 };

--- a/test/geocoderfactory.js
+++ b/test/geocoderfactory.js
@@ -203,6 +203,17 @@
                     .to
                     .throw(Error, 'No geocoder provider find for : zaertyazeaze');
             });
+
+            it('called with "google", "https" and extra timeout must return google geocoder with http adapter and timeout', function() {
+                var timeout = 5 * 1000;
+                var geocoder = GeocoderFactory.getGeocoder('google', 'https', {clientId: 'CLIENT_ID', apiKey: 'API_KEY', timeout: timeout});
+
+                var geocoderAdapter = geocoder._geocoder;
+
+                geocoderAdapter.should.be.instanceof(GoogleGeocoder);
+                geocoderAdapter.httpAdapter.options.timeout.should.be.equal(timeout);
+                geocoderAdapter.httpAdapter.should.be.instanceof(HttpsAdapter);
+            });
         });
     });
 

--- a/test/httpadapter/httpadapter.js
+++ b/test/httpadapter/httpadapter.js
@@ -6,6 +6,7 @@
         sinon = require('sinon');
 
     var HttpAdapter = require('../../lib/httpadapter/httpadapter.js');
+    var HttpError = require('../../lib/error/httperror.js');
 
     describe('HttpAdapter', function() {
 
@@ -26,6 +27,14 @@
                 var httpAdapter = new HttpAdapter(mockedHttp);
 
                 httpAdapter.http.should.equal(mockedHttp);
+            });
+
+            it('if client specified timeout use it', function() {
+                var options = { timeout: 5 * 1000 };
+
+                var httpAdapter = new HttpAdapter(null, options);
+
+                httpAdapter.options.timeout.should.equal(options.timeout);
             });
 
         });
@@ -69,6 +78,21 @@
                 mock.verify();
             });
 
+            it('get must call http request with timeout', function(done) {
+                var options = { timeout: 5 * 1000 };
+
+                this.timeout(options.timeout + 1000);
+
+                var httpAdapter = new HttpAdapter(null, options);
+
+                httpAdapter.get('http://www.google.com', {}, function(err) {
+                  if(err instanceof HttpError && typeof err.code !== 'undefined') {
+                    err.code.should.equal('ETIMEDOUT');
+                  }
+
+                  done();
+                });
+            });
         });
 
     });


### PR DESCRIPTION
Built in node timeout can be too long. Helpful to be able to override at client level.

* adds `timeout` option to `HttpAdapter`
* will throw `HttpError` which mimics nodes built in timeout error
* to test, will need to kill your network connection (otherwise will silently succeed)