### PR TITLE
Add Opendata France geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ var geocoder = require('node-geocoder')(geocoderProvider, httpAdapter, extra);
 * `geocodio`: Geocodio, Supports address geocoding and reverse geocoding (US only)
 * `yandex`: Yandex support address geocoding, you can use `extra.language` to specify language
 * `teleport`: Teleport supports city and urban area forward and reverse geocoding; for more information, see [Teleport API documentation](https://developers.teleport.org/api/)
+* `opendata france`: OpendataFranceGeocoder supports forward and reverse geocoding in France; for more information, see [OpendataFrance API documentation](https://adresse.data.gouv.fr/api/)
 
 ## Http adapter
 

--- a/lib/geocoder/opendatafrancegeocoder.js
+++ b/lib/geocoder/opendatafrancegeocoder.js
@@ -1,0 +1,155 @@
+var util             = require('util'),
+    AbstractGeocoder = require('./abstractgeocoder');
+
+/**
+ * Constructor
+ */
+var OpendataFranceGeocoder = function OpendataFranceGeocoder(httpAdapter, options) {
+    this.options = ['language','email','apiKey'];
+
+    OpendataFranceGeocoder.super_.call(this, httpAdapter, options);
+};
+
+util.inherits(OpendataFranceGeocoder, AbstractGeocoder);
+
+OpendataFranceGeocoder.prototype._endpoint = 'http://api-adresse.data.gouv.fr/search';
+
+OpendataFranceGeocoder.prototype._endpoint_reverse = 'http://api-adresse.data.gouv.fr/reverse';
+
+/**
+* Geocode
+* @param <string|object>   value    Value to geocode (Address or parameters, as specified at https://opendatafrance/api/)
+* @param <function> callback Callback method
+*/
+OpendataFranceGeocoder.prototype._geocode = function(value, callback) {
+    var _this = this;
+
+    var params = this._getCommonParams();
+
+    if (typeof value == 'string') {
+      params.q = value;
+    } else {
+      if (value.address) {
+        params.q = value.address;
+      }
+    }
+    this._forceParams(params);
+
+    this.httpAdapter.get(this._endpoint, params, function(err, result) {
+        if (err) {
+            return callback(err);
+        } else {
+
+            if (result.error) {
+              return callback(new Error(result.error));
+            }
+
+            var results = [];
+
+            if (result.features) {
+              for (var i = 0; i < result.features.length; i++) {
+                results.push(_this._formatResult(result.features[i]));
+              }
+            }
+
+            results.raw = result;
+            callback(false, results);
+        }
+
+    });
+
+};
+
+OpendataFranceGeocoder.prototype._formatResult = function(result) {
+
+    var latitude = result.geometry.coordinates[1];
+    if (latitude) {
+      latitude = parseFloat(latitude);
+    }
+
+    var longitude = result.geometry.coordinates[0];
+    if (longitude) {
+      longitude = parseFloat(longitude);
+    }
+
+    var properties = result.properties;
+
+    return {
+        'latitude' : latitude,
+        'longitude' : longitude,
+        'state' : properties.context,
+        'city' : properties.city,
+        'zipcode' : properties.postcode,
+        'streetName': properties.street,
+        'streetNumber' : properties.housenumber,
+        'countryCode' : 'FR',
+        'country' : 'France'
+    };
+};
+
+/**
+* Reverse geocoding
+* @param {lat:<number>,lon:<number>, ...}  lat: Latitude, lon: Longitude, ... see https://wiki.openstreetmap.org/wiki/Nominatim#Parameters_2
+* @param <function> callback Callback method
+*/
+OpendataFranceGeocoder.prototype._reverse = function(query, callback) {
+
+    var _this = this;
+
+    var params = this._getCommonParams();
+    for (var k in query) {
+      var v = query[k];
+      params[k] = v;
+    }
+    this._forceParams(params);
+
+    this.httpAdapter.get(this._endpoint_reverse , params, function(err, result) {
+        if (err) {
+            return callback(err);
+        } else {
+
+          if(result.error) {
+            return callback(new Error(result.error));
+          }
+
+          var results = [];
+
+          if (result.features) {
+            for (var i = 0; i < result.features.length; i++) {
+              results.push(_this._formatResult(result.features[i]));
+            }
+          }
+
+          results.raw = result;
+          callback(false, results);
+        }
+    });
+};
+
+/**
+* Prepare common params
+*
+* @return <Object> common params
+*/
+OpendataFranceGeocoder.prototype._getCommonParams = function(){
+    var params = {};
+
+    for (var k in this.options) {
+      var v = this.options[k];
+      if (!v) {
+        continue;
+      }
+      if (k === 'language') {
+        k = 'accept-language';
+      }
+      params[k] = v;
+    }
+
+    return params;
+};
+
+OpendataFranceGeocoder.prototype._forceParams = function(params){
+  params.limit = 20;
+};
+
+module.exports = OpendataFranceGeocoder;

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -105,11 +105,15 @@ var GeocoderFactory = {
 
       return new SmartyStreets(adapter, extra.auth_id, extra.auth_token);
     }
-
     if (geocoderName === 'teleport') {
       var TeleportGeocoder = require('./geocoder/teleportgeocoder.js');
 
       return new TeleportGeocoder(adapter, extra.apiKey, extra);
+    }
+    if (geocoderName === 'opendatafrance') {
+      var OpendataFranceGeocoder = require('./geocoder/opendatafrancegeocoder.js');
+
+      return new OpendataFranceGeocoder(adapter);
     }
 
     throw new Error('No geocoder provider find for : ' + geocoderName);

--- a/test/geocoder/opendatafrancegeocoder.js
+++ b/test/geocoder/opendatafrancegeocoder.js
@@ -1,0 +1,253 @@
+(function() {
+    var chai = require('chai'),
+        should = chai.should(),
+        expect = chai.expect,
+        sinon = require('sinon');
+
+    var OpendataFranceGeocoder = require('../../lib/geocoder/opendatafrancegeocoder.js');
+
+    var mockedHttpAdapter = {
+        get: function() {}
+    };
+
+    describe('OpendataFranceGeocoder', function() {
+
+        describe('#constructor' , function() {
+
+            it('an http adapter must be set', function() {
+
+                expect(function() {new OpendataFranceGeocoder();}).to.throw(Error, 'OpendataFranceGeocoder need an httpAdapter');
+            });
+
+            it('Should be an instance of OpendataFranceGeocoder', function() {
+
+                var osmAdapter = new OpendataFranceGeocoder(mockedHttpAdapter);
+
+                osmAdapter.should.be.instanceof(OpendataFranceGeocoder);
+            });
+
+        });
+
+        describe('#geocode' , function() {
+
+            it('Should not accept IPv4', function() {
+
+                var osmAdapter = new OpendataFranceGeocoder(mockedHttpAdapter);
+
+                expect(function() {
+                        osmAdapter.geocode('127.0.0.1');
+                }).to.throw(Error, 'OpendataFranceGeocoder does not support geocoding IPv4');
+
+            });
+
+            it('Should not accept IPv6', function() {
+
+                var osmAdapter = new OpendataFranceGeocoder(mockedHttpAdapter);
+
+                expect(function() {
+                        osmAdapter.geocode('2001:0db8:0000:85a3:0000:0000:ac1f:8001');
+                }).to.throw(Error, 'OpendataFranceGeocoder does not support geocoding IPv6');
+
+            });
+
+            it('Should call httpAdapter get method', function() {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().returns({then: function() {}});
+
+                var osmAdapter = new OpendataFranceGeocoder(mockedHttpAdapter);
+
+                osmAdapter.geocode('1 champs élysée Paris');
+
+                mock.verify();
+
+            });
+
+            it('Should return geocoded address', function(done) {
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, {
+                  "licence": "ODbL 1.0",
+                  "type": "FeatureCollection",
+                  "attribution": "BAN",
+                  "limit": 5,
+                  "features": [
+                    {
+                      "properties": {
+                        "score": 0.8551727272727272,
+                        "citycode": "75119",
+                        "postcode": "75019",
+                        "type": "housenumber",
+                        "name": "1 Rue David d'Angers",
+                        "city": "Paris",
+                        "housenumber": "1",
+                        "context": "75, Île-de-France",
+                        "street": "Rue David d'Angers",
+                        "id": "ADRNIVX_0000000270725006",
+                        "label": "1 Rue David d'Angers 75019 Paris"
+                      },
+                      "geometry": {
+                        "coordinates": [
+                          2.388491,
+                          48.88313
+                        ],
+                        "type": "Point"
+                      },
+                      "type": "Feature"
+                    }
+                  ],
+                  "version": "draft",
+                  "query": "1 rue david d'angers"
+                }
+                );
+
+                var osmAdapter = new OpendataFranceGeocoder(mockedHttpAdapter);
+
+                osmAdapter.geocode('135 pilkington avenue, birmingham', function(err, results) {
+                    mock.verify();
+
+                    err.should.to.equal(false);
+
+                    results[0].should.to.deep.equal({
+                        "latitude": 48.88313,
+                        "longitude": 2.388491,
+                        "country": "France",
+						            "state": "75, Île-de-France",
+                        "city": "Paris",
+                        "zipcode": "75019",
+                        "streetName": "Rue David d'Angers",
+                        "streetNumber": "1",
+                        "countryCode": "FR"
+                    });
+
+                    results.raw.should.deep.equal({
+                      "licence": "ODbL 1.0",
+                      "type": "FeatureCollection",
+                      "attribution": "BAN",
+                      "limit": 5,
+                      "features": [
+                        {
+                          "properties": {
+                            "score": 0.8551727272727272,
+                            "citycode": "75119",
+                            "postcode": "75019",
+                            "type": "housenumber",
+                            "name": "1 Rue David d'Angers",
+                            "city": "Paris",
+                            "housenumber": "1",
+                            "context": "75, Île-de-France",
+                            "street": "Rue David d'Angers",
+                            "id": "ADRNIVX_0000000270725006",
+                            "label": "1 Rue David d'Angers 75019 Paris"
+                          },
+                          "geometry": {
+                            "coordinates": [
+                              2.388491,
+                              48.88313
+                            ],
+                            "type": "Point"
+                          },
+                          "type": "Feature"
+                        }
+                      ],
+                      "version": "draft",
+                      "query": "1 rue david d'angers"
+                    });
+
+                    mock.verify();
+                    done();
+                });
+            });
+        });
+
+        describe('#reverse' , function() {
+            it('Should return geocoded address', function(done) {
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').once().callsArgWith(2, false, {
+                    "licence": "ODbL 1.0",
+                    "type": "FeatureCollection",
+                    "attribution": "BAN",
+                    "limit": 1,
+                    "features": [
+                      {
+                        "properties": {
+                          "score": 0.9999998584949208,
+                          "postcode": "49100",
+                          "housenumber": "16",
+                          "street": "Rue Chateaugontier",
+                          "context": "49, Maine-et-Loire, Pays de la Loire",
+                          "citycode": "49007",
+                          "type": "housenumber",
+                          "city": "Angers",
+                          "name": "16 Rue Chateaugontier",
+                          "label": "16 Rue Chateaugontier 49100 Angers",
+                          "id": "49007_1720_665e82",
+                          "distance": 18
+                        },
+                        "geometry": {
+                          "coordinates": [
+                            -0.54994,
+                            47.46653
+                          ],
+                          "type": "Point"
+                        },
+                        "type": "Feature"
+                      }
+                    ],
+                    "version": "draft"
+                  }
+                );
+                var osmAdapter = new OpendataFranceGeocoder(mockedHttpAdapter);
+                osmAdapter.reverse({lat: 47.46653, lon: -0.550142}, function(err, results) {
+                        err.should.to.equal(false);
+                        results[0].should.to.deep.equal({
+                            "latitude": 47.46653,
+                            "longitude": -0.54994,
+                            "country": "France",
+                            "state": "49, Maine-et-Loire, Pays de la Loire",
+                            "city": "Angers",
+                            "zipcode": "49100",
+                            "streetName": "Rue Chateaugontier",
+                            "streetNumber": "16",
+                            "countryCode": "FR"
+                        });
+                        results.raw.should.deep.equal({
+                          "licence": "ODbL 1.0",
+                          "type": "FeatureCollection",
+                          "attribution": "BAN",
+                          "limit": 1,
+                          "features": [
+                            {
+                              "properties": {
+                                "score": 0.9999998584949208,
+                                "postcode": "49100",
+                                "housenumber": "16",
+                                "street": "Rue Chateaugontier",
+                                "context": "49, Maine-et-Loire, Pays de la Loire",
+                                "citycode": "49007",
+                                "type": "housenumber",
+                                "city": "Angers",
+                                "name": "16 Rue Chateaugontier",
+                                "label": "16 Rue Chateaugontier 49100 Angers",
+                                "id": "49007_1720_665e82",
+                                "distance": 18
+                              },
+                              "geometry": {
+                                "coordinates": [
+                                  -0.54994,
+                                  47.46653
+                                ],
+                                "type": "Point"
+                              },
+                              "type": "Feature"
+                            }
+                          ],
+                          "version": "draft"
+                        });
+
+                        mock.verify();
+                        done();
+                });
+            });
+        });
+    });
+})();


### PR DESCRIPTION
I implemented support for forward and reverse city geocoding using opendata from french government portal.

Full documentation of this API is here : https://adresse.data.gouv.fr/api/

Unit testing included

Let me know if there's anything that needs to be changed in order to merge.

We will use this module with this geocoder soon in one of our project ;)
