### PR TITLE
feat: adds locationiq geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ geocoder.geocode('29 champs elysée paris')
 }]
 ```
 
-## Advanced usage (only google, here, mapquest, and opencage providers)
+## Advanced usage (only google, here, mapquest, locationiq, and opencage providers)
 
 ```javascript
 geocoder.geocode({address: '29 champs elysée', country: 'France', zipcode: '75008'}, function(err, res) {
@@ -122,6 +122,10 @@ var geocoder = NodeGeocoder({
   * For `reverse`, you can use additional parameters from https://wiki.openstreetmap.org/wiki/Nominatim#Parameters_2
   * You should specify a specific `user-agent` or `referrer` header field as required by
   https://wiki.openstreetmap.org/wiki/Nominatim_usage_policy
+* `locationiq` : LocationIQGeocoder. Supports address geocoding and reverse geocoding just like openstreetmap but does require only a locationiq api key to be set.
+  * For `geocode` you can use simple `q` parameter or an object containing th edifferent parameters defined here: http://locationiq.org/#docs
+  * For `reverse`, you can pass over `{lat, lon}` and additional parameters defined in http://locationiq.org/#docs
+  * No need to specify referer or email addresses, just locationiq api key, note that there are rate limits!
 * `mapquest` : MapQuestGeocoder. Supports address geocoding and reverse geocoding. Needs an apiKey
 * `openmapquest` : Open MapQuestGeocoder (based on OpenStreetMapGeocoder). Supports address geocoding and reverse geocoding. Needs an apiKey
 * `agol` : ArcGis Online Geocoding service. Supports geocoding and reverse. Requires a client_id & client_secret and 'https' http adapter

--- a/lib/geocoder/locationiqgeocoder.js
+++ b/lib/geocoder/locationiqgeocoder.js
@@ -1,0 +1,160 @@
+var
+  querystring      = require('querystring'),
+  util             = require('util'),
+  AbstractGeocoder = require('./abstractgeocoder');
+
+/**
+ * Constructor
+ *
+ * Geocoder for LocationIQ
+ * http://locationiq.org/#docs
+ *
+ * @param {[type]} httpAdapter [description]
+ * @param {String} apiKey      [description]
+ */
+var LocationIQGeocoder = function LocationIQGeocoder(httpAdapter, apiKey) {
+
+  LocationIQGeocoder.super_.call(this, httpAdapter);
+
+  if (!apiKey || apiKey == 'undefined') {
+    throw new Error('LocationIQGeocoder needs an apiKey');
+  }
+
+  this.apiKey = querystring.unescape(apiKey);
+};
+
+util.inherits(LocationIQGeocoder, AbstractGeocoder);
+
+LocationIQGeocoder.prototype._endpoint = 'http://locationiq.org/v1';
+LocationIQGeocoder.prototype._endpoint_reverse = 'http://osm1.unwiredlabs.com/locationiq/v1/reverse.php';
+
+/**
+ * Geocode
+ * @param  {string|object}   value
+ *   Value to geocode (Adress String or parameters as specified over at
+ *   http://locationiq.org/#docs)
+ * @param  {Function} callback callback method
+ */
+LocationIQGeocoder.prototype._geocode = function(value, callback) {
+  var params = this._getCommonParams();
+
+  if (typeof value === 'string') {
+    params.q = value;
+  } else {
+    for (var k in value) {
+      var v = value[k];
+      switch(k) {
+        default:
+          params[k] = v;
+          break;
+        // alias for postalcode
+        case 'zipcode':
+          params.postalcode = v;
+          break;
+        // alias for street
+        case 'address':
+          params.street = v;
+          break;
+      }
+    }
+  }
+  this._forceParams(params);
+
+  this.httpAdapter.get(this._endpoint + '/search.php', params,
+    function(err, responseData) {
+      if (err) {
+        return callback(err);
+      }
+
+      // when there’s no err thrown here the resulting array object always
+      // seemes to be defined but empty so no need to check for
+      // responseData.error for now
+
+      var results = responseData.map(this._formatResult).filter(function(result) {
+        return result.longitude && result.latitude;
+      });
+      results.raw = responseData;
+
+      callback(false, results);
+    }.bind(this));
+};
+
+/**
+ * Reverse geocoding
+ * @param  {lat:<number>,lon<number>}   query    lat: Latitude, lon: Longitutde and additional parameters as specified here: http://locationiq.org/#docs
+ * @param  {Function} callback Callback method
+ */
+LocationIQGeocoder.prototype._reverse = function(query, callback) {
+  var params = this._getCommonParams();
+
+  for (var k in query) {
+    var v = query[k];
+    params[k] = v;
+  }
+  this._forceParams(params);
+
+  this.httpAdapter.get(this._endpoint_reverse, params,
+    function(err, responseData) {
+      if (err) {
+        return callback(err);
+      }
+
+      // when there’s no err thrown here the resulting array object always
+      // seemes to be defined but empty so no need to check for
+      // responseData.error for now
+
+      // locationiq always seemes to answer with a single object instead
+      // of an array
+      var results = [responseData].map(this._formatResult).filter(function(result) {
+        return result.longitude && result.latitude;
+      });
+      results.raw = responseData;
+
+      callback(false, results);
+    }.bind(this));
+};
+
+LocationIQGeocoder.prototype._formatResult = function(result) {
+  // transform lat and lon to real floats
+  var transformedResult = {
+    'latitude' : result.lat ? parseFloat(result.lat) : undefined,
+    'longitude' : result.lon ? parseFloat(result.lon) : undefined
+  };
+
+  if (result.address) {
+    transformedResult.country = result.address.country;
+    transformedResult.country = result.address.country;
+    transformedResult.city = result.address.city || result.address.town || result.address.village || result.address.hamlet;
+    transformedResult.state = result.address.state;
+    transformedResult.zipcode = result.address.postcode;
+    transformedResult.streetName = result.address.road || result.address.cycleway;
+    transformedResult.streetNumber = result.address.house_number;
+    // make sure countrycode is always uppercase to keep node-geocoder api formats
+    transformedResult.countryCode = result.address.country_code.toUpperCase();
+  }
+  return transformedResult;
+};
+
+/**
+* Prepare common params
+*
+* @return <Object> common params
+*/
+LocationIQGeocoder.prototype._getCommonParams = function() {
+  return {
+    'key': this.apiKey
+  };
+};
+
+/**
+ * Adds parameters that are enforced
+ *
+ * @param  {object} params object containing the parameters
+ */
+LocationIQGeocoder.prototype._forceParams = function(params) {
+  params.format = 'json';
+  params.addressdetails = '1';
+};
+
+
+module.exports = LocationIQGeocoder;

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -63,6 +63,11 @@ var GeocoderFactory = {
 
       return new OpenStreetMapGeocoder(adapter, {language: extra.language});
     }
+    if (geocoderName === 'locationiq') {
+      var LocationIQGeocoder = require('./geocoder/locationiqgeocoder.js');
+
+      return new LocationIQGeocoder(adapter, extra.apiKey);
+    }
     if (geocoderName === 'mapquest') {
       var MapQuestGeocoder = require('./geocoder/mapquestgeocoder.js');
 

--- a/test/geocoder/locationiqgeocoder.js
+++ b/test/geocoder/locationiqgeocoder.js
@@ -1,0 +1,261 @@
+(function() {
+  var chai = require('chai'),
+      should = chai.should(),
+      expect = chai.expect,
+      sinon = require('sinon');
+
+  var LocationIQGeocoder = require('../../lib/geocoder/locationiqgeocoder.js');
+
+  var mockedHttpAdapter = {
+    get: function() {}
+  };
+
+  describe('LocationIQGeocoder', function() {
+
+    describe('#constructor', function() {
+
+      it('an http adapter must be set', function() {
+        expect(function() {
+          new LocationIQGeocoder();
+        }).to.throw(Error, 'ocationIQGeocoder need an httpAdapter');
+      });
+
+      it('must have an api key as second argument', function() {
+        expect(function() {
+          new LocationIQGeocoder(mockedHttpAdapter);
+        }).to.throw(Error, 'LocationIQGeocoder needs an apiKey');
+      });
+
+      it('Should be an instance of LocationIQGeocoder', function() {
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        adapter.should.be.instanceOf(LocationIQGeocoder);
+      });
+
+    });
+
+    describe('#geocode', function() {
+
+      it('Should not accept IPv4', function() {
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        expect(function() {
+                adapter.geocode('127.0.0.1');
+        }).to.throw(Error, 'LocationIQGeocoder does not support geocoding IPv4');
+      });
+
+      it('Should not accept IPv6', function() {
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        expect(function() {
+                adapter.geocode('2001:0db8:0000:85a3:0000:0000:ac1f:8001');
+        }).to.throw(Error, 'LocationIQGeocoder does not support geocoding IPv6');
+      });
+
+      it('Should call httpAdapter get method', function() {
+        var mock = sinon.mock(mockedHttpAdapter);
+        mock.expects('get').once().returns({then: function() {}});
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        adapter.geocode('Empire State Building');
+        mock.verify();
+      });
+
+      it('Should return geocoded address', function(done) {
+        var mock = sinon.mock(mockedHttpAdapter);
+        var rawResponse = [{
+          "place_id": "49220656",
+          "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+          "osm_type": "node",
+          "osm_id": "3674260525",
+          "boundingbox": [
+            "40.7487227",
+            "40.7488227",
+            "-73.9849836",
+            "-73.9848836"
+          ],
+          "lat": "40.7487727",
+          "lon": "-73.9849336",
+          "display_name": "Empire State Building, 362, 5th Avenue, Diamond District, Manhattan, New York County, NYC, New York, 10035, United States of America",
+          "class": "tourism",
+          "type": "attraction",
+          "importance": 0.301,
+          "icon": "http://158.69.3.42/nominatim/images/mapicons/poi_point_of_interest.p.20.png",
+          "address": {
+            "attraction": "Empire State Building",
+            "house_number": "362",
+            "road": "5th Avenue",
+            "neighbourhood": "Diamond District",
+            "suburb": "Manhattan",
+            "county": "New York County",
+            "city": "NYC",
+            "state": "New York",
+            "postcode": "10035",
+            "country": "United States of America",
+            "country_code": "us"
+          }
+        }];
+        mock.expects('get').once().callsArgWith(2, false, rawResponse);
+
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        adapter.geocode('Empire State Building', function(err, results) {
+          mock.verify();
+          err.should.equal(false);
+
+          results.should.have.property('raw');
+          results.raw.should.deep.equal(rawResponse);
+
+          results[0].should.deep.equal({
+            'city': 'NYC',
+            'country': 'United States of America',
+            'countryCode': 'US',
+            'latitude': 40.7487727,
+            'longitude': -73.9849336,
+            'state': 'New York',
+            'streetName': '5th Avenue',
+            'streetNumber': '362',
+            'zipcode': '10035'
+          });
+
+        });
+        mock.verify();
+        done();
+      });
+
+      it('Should return geocoded address when queried with an object', function(done) {
+        var mock = sinon.mock(mockedHttpAdapter);
+        var rawResponse = [{
+          "place_id": "49220656",
+          "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+          "osm_type": "node",
+          "osm_id": "3674260525",
+          "boundingbox": [
+            "40.7487227",
+            "40.7488227",
+            "-73.9849836",
+            "-73.9848836"
+          ],
+          "lat": "40.7487727",
+          "lon": "-73.9849336",
+          "display_name": "Empire State Building, 362, 5th Avenue, Diamond District, Manhattan, New York County, NYC, New York, 10035, United States of America",
+          "class": "tourism",
+          "type": "attraction",
+          "importance": 0.401,
+          "icon": "http://158.69.3.42/nominatim/images/mapicons/poi_point_of_interest.p.20.png",
+          "address": {
+            "attraction": "Empire State Building",
+            "house_number": "362",
+            "road": "5th Avenue",
+            "neighbourhood": "Diamond District",
+            "suburb": "Manhattan",
+            "county": "New York County",
+            "city": "NYC",
+            "state": "New York",
+            "postcode": "10035",
+            "country": "United States of America",
+            "country_code": "us"
+          }
+        }];
+        mock.expects('get').once().callsArgWith(2, false, rawResponse);
+
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        var query = {
+          'street': '5th Avenue 263',
+          'city': 'New York'
+        };
+        adapter.geocode(query, function(err, results) {
+          mock.verify();
+          err.should.equal(false);
+
+          results.should.have.length.of(1);
+          results[0].should.deep.equal({
+            'city': 'NYC',
+            'country': 'United States of America',
+            'countryCode': 'US',
+            'latitude': 40.7487727,
+            'longitude': -73.9849336,
+            'state': 'New York',
+            'streetName': '5th Avenue',
+            'streetNumber': '362',
+            'zipcode': '10035'
+          });
+
+          results.should.have.property('raw');
+          results.raw.should.deep.equal(rawResponse);
+        });
+        mock.verify();
+        done();
+      });
+
+      it('should ignore "format" and "addressdetails" arguments', function(done) {
+        var mock = sinon.mock(mockedHttpAdapter);
+        mock.expects('get').once().callsArgWith(2, false, [])
+          .withArgs('http://locationiq.org/v1/search.php', {
+            addressdetails: '1',
+            format: 'json',
+            key: 'API_KEY',
+            q:'Athens'
+          });
+
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        var query = {q:'Athens',format:'xml',addressdetails:0};
+        adapter.geocode(query, function(err, results) {
+          err.should.equal(false);
+          results.should.have.length.of(0);
+          mock.verify();
+          done();
+        });
+      });
+
+    });
+
+    describe('#reverse', function() {
+
+      it('Should correctly set extra arguments', function(done) {
+        var mock = sinon.mock(mockedHttpAdapter);
+        mock.expects('get').once().callsArgWith(2, false, [])
+          .withArgs('http://osm1.unwiredlabs.com/locationiq/v1/reverse.php', {
+            addressdetails: '1',
+            format: 'json',
+            key: 'API_KEY',
+            lat: 12,
+            lon: 7,
+            zoom: 15 // <--- extra
+          });
+
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        adapter.reverse({lat:12,lon:7,zoom:15}, function(err, result) {
+          err.should.equal(false);
+          // check for empty result
+          result.should
+            .be.an('array')
+            .have.length.of(0);
+          mock.verify();
+          done();
+        });
+      });
+
+      it('should ignore "format" and "addressdetails" arguments', function(done) {
+        var mock = sinon.mock(mockedHttpAdapter);
+        mock.expects('get').once().callsArgWith(2, false, [])
+          .withArgs('http://osm1.unwiredlabs.com/locationiq/v1/reverse.php', {
+            addressdetails: '1',
+            format: 'json',
+            key: 'API_KEY',
+            lat: 12,
+            lon: 7
+          });
+
+        var adapter = new LocationIQGeocoder(mockedHttpAdapter, 'API_KEY');
+        var query = {lat:12,lon:7,format:'xml',addressdetails:0};
+        adapter.reverse(query, function(err, result) {
+          err.should.equal(false);
+          // check for empty result
+          result.should
+            .be.an('array')
+            .have.length.of(0);
+          mock.verify();
+          done();
+        });
+      });
+
+    });
+
+  });
+})();

--- a/test/geocoderfactory.js
+++ b/test/geocoderfactory.js
@@ -9,6 +9,7 @@ var HereGeocoder = require('../lib/geocoder/heregeocoder.js');
 var GeocoderFactory = require('../lib/geocoderfactory.js');
 var DataScienceToolkitGeocoder = require('../lib/geocoder/datasciencetoolkitgeocoder.js');
 var OpenStreetMapGeocoder = require('../lib/geocoder/openstreetmapgeocoder.js');
+var LocationIQGeocoder = require('../lib/geocoder/locationiqgeocoder.js');
 
 var HttpAdapter  = require('../lib/httpadapter/httpadapter.js'),
     HttpsAdapter = require('../lib/httpadapter/httpsadapter.js');
@@ -205,6 +206,15 @@ describe('GeocoderFactory', function() {
             var geocoderAdapter = geocoder._geocoder;
 
             geocoderAdapter.should.be.instanceof(OpenStreetMapGeocoder);
+            geocoderAdapter.httpAdapter.should.be.instanceof(HttpAdapter);
+        });
+
+        it('called with "locationiq" and "http" must return locationiq geocoder with http adapter', function() {
+            var geocoder = GeocoderFactory.getGeocoder('locationiq', 'http', {apiKey: 'API_KEY'});
+
+            var geocoderAdapter = geocoder._geocoder;
+
+            geocoderAdapter.should.be.instanceof(LocationIQGeocoder, 'api-key');
             geocoderAdapter.httpAdapter.should.be.instanceof(HttpAdapter);
         });
 


### PR DESCRIPTION
Adds an other provider which connects to [locationiq](http://locationiq.org/) where openstreetmap data is made available as "blazing fast geocoding" and just an api key is required to authentificate.

Tests included.

Relates to #178 