### PR TITLE
Fix: `raw` attribute gone missing from results

### DIFF
--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -107,13 +107,16 @@ Geocoder.prototype._format = function (data) {
         return data;
       }
 
-      Object.defineProperty(data,'raw',{configurable:false, enumerable:false, writable:false});
+      var _raw = data.raw;
 
       data = data.map(function(result) {
         result.provider = _this._geocoder.name;
 
         return result;
       });
+
+      data.raw = _raw;
+      Object.defineProperty(data,'raw',{configurable:false, enumerable:false, writable:false});
 
       return data;
     })


### PR DESCRIPTION
In the process of mapping provider names to results in 2b189b9, it looks like the `raw` attribute of the `data` object is lost.

This pull request simply captures the `raw` attribute and re-sets it (with the intended property configuration) after the mapping process.

There may well be a more elegant way to do this, but I’m hoping this is a simple fix.