### PR TITLE
Handling http response with code different than 200

### DIFF
--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -67,18 +67,21 @@ GoogleGeocoder.prototype._geocode = function (value, callback) {
   this._signedRequest(this._endpoint, params);
   this.httpAdapter.get(this._endpoint, params, function (err, result) {
     if (err) {
-      return callback(err);
+      // status should be "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
+        if (result) {
+          return _this._handleNonOkResult(err, result, callback);
+        }
+        return callback(err);
     } else {
       var results = [];
-      // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
-      // error_message may or may not be present
+      // status can be "OK", "ZERO_RESULTS"
       if (result.status === 'ZERO_RESULTS') {
         results.raw = result;
         return callback(false, results);
       }
 
       if (result.status !== 'OK') {
-        return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')), {raw: result});
+        return _this._handleNonOkResult(null, result, callback);
       }
 
       for (var i = 0; i < result.results.length; i++) {
@@ -98,6 +101,17 @@ GoogleGeocoder.prototype._geocode = function (value, callback) {
 
   });
 
+};
+
+GoogleGeocoder.prototype._handleNonOkResult = function(error, result, callback){
+
+  if (!error) {
+    error = new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : ''));
+  }
+
+  error.raw = result;
+
+  return callback(error, {raw: result});
 };
 
 GoogleGeocoder.prototype._prepareQueryString = function () {
@@ -259,12 +273,16 @@ GoogleGeocoder.prototype._reverse = function (query, callback) {
   this._signedRequest(this._endpoint, params);
   this.httpAdapter.get(this._endpoint, params, function (err, result) {
     if (err) {
+      if (result) {
+        return _this._handleNonOkResult(err, result, callback);
+      }
+
       return callback(err);
     } else {
       // status can be "OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", or "UNKNOWN_ERROR"
       // error_message may or may not be present
       if (result.status !== 'OK') {
-        return callback(new Error('Status is ' + result.status + '.' + (result.error_message ? ' ' + result.error_message : '')), {raw: result});
+        return _this._handleNonOkResult(null, result, callback);
       }
 
       var results = [];

--- a/lib/httpadapter/httpadapter.js
+++ b/lib/httpadapter/httpadapter.js
@@ -26,6 +26,7 @@ var HttpAdapter = function(http, options) {
 */
 HttpAdapter.prototype.get = function(url, params, callback) {
 
+  var _this = this;
   var urlParsed = this.url.parse(url);
   var options = {
     host: urlParsed.host,
@@ -55,14 +56,10 @@ HttpAdapter.prototype.get = function(url, params, callback) {
     //the whole response has been recieved, so we just print it out here
     response.on('end', function() {
       if (response.statusCode !== 200) {
-        return callback(new Error('Response status code is ' + response.statusCode), null);
+        return callback(new Error('Response status code is ' + response.statusCode), _this._formatContent(contentType, str));
       }
 
-      if (contentType !== undefined && contentType.indexOf('application/json') >= 0) {
-        callback(false, JSON.parse(str));
-      } else {
-        callback(false, str);
-      }
+      return callback(false, _this._formatContent(contentType, str));
 
     });
   });
@@ -89,6 +86,17 @@ HttpAdapter.prototype.get = function(url, params, callback) {
   });
 
   request.end();
+};
+
+HttpAdapter.prototype._formatContent = function(contentType, content) {
+
+  var formattedContent = content;
+
+  if (contentType !== undefined && contentType.indexOf('application/json') >= 0) {
+    formattedContent = JSON.parse(content);
+  }
+
+  return formattedContent;
 };
 
 HttpAdapter.prototype.supportsHttps = function() {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   },
   "devDependencies": {
     "chai": "^1.8.1",
-    "mocha": "2.4.5",
     "eslint": "^0.24.1",
+    "mocha": "2.4.5",
+    "nock": "^8.0.0",
     "sinon": "^1.17.3"
   },
   "eslintConfig": {

--- a/test/geocoder/googlegeocoder.js
+++ b/test/geocoder/googlegeocoder.js
@@ -252,7 +252,7 @@
                    done();
                 });
             });
-            
+
             it('Should handle a not "OK" status', function(done) {
                 var mock = sinon.mock(mockedHttpAdapter);
                 mock.expects('get').once().callsArgWith(2, false, { status: "OVER_QUERY_LIMIT", error_message: "You have exceeded your rate-limit for this API.", results: [] });
@@ -575,6 +575,25 @@
 
                 googleAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
                     err.message.should.to.equal("Status is INVALID_REQUEST.");
+                    mock.verify();
+                    done();
+                });
+            });
+
+            it('Should handle error from httpAdapter with result from http call', function(done) {
+                var mock = sinon.mock(mockedHttpAdapter);
+                var error = new Error('An error from Google API with status code 400 or 500.');
+                mock.expects('get').once().callsArgWith(2, error, { status: "INVALID_REQUEST", results: [] });
+
+                var googleAdapter = new GoogleGeocoder(mockedHttpAdapter);
+
+                googleAdapter.reverse({lat:40.714232,lon:-73.9612889}, function(err, results) {
+                    err.message.should.to.equal("An error from Google API with status code 400 or 500.");
+                    expect(err).to.haveOwnProperty('raw');
+                    expect(err.raw.status).to.be.equal('INVALID_REQUEST');
+                    expect(results).to.hasOwnProperty('raw');
+                    expect(results.raw.status).to.be.equal('INVALID_REQUEST');
+
                     mock.verify();
                     done();
                 });


### PR DESCRIPTION
 Bluebird does not support by default callback with error and result both defined. If error is defined then result will be null. Modifying as well the HttpAdapter to pass the error to Google geocoder factory
