### PR TITLE
Make it work in the browser with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.15.0",
   "description": "Node Geocoder, node geocoding library, supports google maps, mapquest, open street map, tom tom, promise",
   "main": "index.js",
+  "browser": {
+    "net": "net-browserify"
+  },
   "scripts": {
     "test": "./node_modules/.bin/mocha --check-leaks",
     "lint": "./node_modules/.bin/eslint lib"
@@ -29,6 +32,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
+    "net-browserify": "^0.2.4",
     "request": "^2.74.0",
     "request-promise": "^4.1.1"
   },


### PR DESCRIPTION
By adding [npm-browserify](https://www.npmjs.com/package/net-browserify) as dependency and indicating it in the "browser" field of package.json, `node-geocoder` runs perfectly in the browser when using browserify.

Otherwise,  `require('net')` returns an empty Object (without `isIPv4()` methods, etc, so the lib fails).