### PR TITLE
Update heregeocoder.js

### DIFF
--- a/lib/geocoder/heregeocoder.js
+++ b/lib/geocoder/heregeocoder.js
@@ -19,7 +19,7 @@ var HereGeocoder = function HereGeocoder(httpAdapter, options) {
 util.inherits(HereGeocoder, AbstractGeocoder);
 
 // Here geocoding API endpoint
-HereGeocoder.prototype._geocodeEndpoint = 'https://geocoder.api.here.com/6.2/geocode.json';
+HereGeocoder.prototype._geocodeEndpoint = 'https://geocoder.cit.api.here.com/6.2/geocode.json';
 
 // Here reverse geocoding API endpoint
 HereGeocoder.prototype._reverseEndpoint = 'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json';


### PR DESCRIPTION
It seems HERE geocodeEndpoint = 'https://geocoder.api.here.com/6.2/geocode.json' is not working. Instead use https://geocoder.cit.api.here.com/6.2/geocode.json