### PR TITLE
Added support for multiple types of a single google address component 

### DIFF
--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -184,69 +184,71 @@ GoogleGeocoder.prototype._formatResult = function (result) {
   };
 
   for (var i = 0; i < result.address_components.length; i++) {
-    var addressType = result.address_components[i].types[0];
-    switch (addressType) {
-      //Country
-      case 'country':
-        extractedObj.country = result.address_components[i].long_name;
-        extractedObj.countryCode = result.address_components[i].short_name;
-        break;
-      //Administrative Level 1
-      case 'administrative_area_level_1':
-        extractedObj.administrativeLevels.level1long = result.address_components[i].long_name;
-        extractedObj.administrativeLevels.level1short = result.address_components[i].short_name;
-        break;
-      //Administrative Level 2
-      case 'administrative_area_level_2':
-        extractedObj.administrativeLevels.level2long = result.address_components[i].long_name;
-        extractedObj.administrativeLevels.level2short = result.address_components[i].short_name;
-        break;
-      //Administrative Level 3
-      case 'administrative_area_level_3':
-        extractedObj.administrativeLevels.level3long = result.address_components[i].long_name;
-        extractedObj.administrativeLevels.level3short = result.address_components[i].short_name;
-        break;
-      //Administrative Level 4
-      case 'administrative_area_level_4':
-        extractedObj.administrativeLevels.level4long = result.address_components[i].long_name;
-        extractedObj.administrativeLevels.level4short = result.address_components[i].short_name;
-        break;
-      //Administrative Level 5
-      case 'administrative_area_level_5':
-        extractedObj.administrativeLevels.level5long = result.address_components[i].long_name;
-        extractedObj.administrativeLevels.level5short = result.address_components[i].short_name;
-        break;
-      // City
-      case 'locality':
-        extractedObj.city = result.address_components[i].long_name;
-        break;
-      // Address
-      case 'postal_code':
-        extractedObj.zipcode = result.address_components[i].long_name;
-        break;
-      case 'route':
-        extractedObj.streetName = result.address_components[i].long_name;
-        break;
-      case 'street_number':
-        extractedObj.streetNumber = result.address_components[i].long_name;
-        break;
-      case 'premise':
-        extractedObj.extra.premise = result.address_components[i].long_name;
-        break;
-      case 'subpremise':
-        extractedObj.extra.subpremise = result.address_components[i].long_name;
-        break;
-      case 'establishment':
-        extractedObj.extra.establishment = result.address_components[i].long_name;
-        break;
-      case 'sublocality_level_1':
-      case 'political':
-      case 'sublocality':
-      case 'neighborhood':
-        if(!extractedObj.extra.neighborhood) {
-          extractedObj.extra.neighborhood = result.address_components[i].long_name;
-        }
-        break;
+    for (var x = 0; x < result.address_components[i].types.length; x++) {
+      var addressType = result.address_components[i].types[x];
+      switch (addressType) {
+        //Country
+        case 'country':
+          extractedObj.country = result.address_components[i].long_name;
+          extractedObj.countryCode = result.address_components[i].short_name;
+          break;
+        //Administrative Level 1
+        case 'administrative_area_level_1':
+          extractedObj.administrativeLevels.level1long = result.address_components[i].long_name;
+          extractedObj.administrativeLevels.level1short = result.address_components[i].short_name;
+          break;
+        //Administrative Level 2
+        case 'administrative_area_level_2':
+          extractedObj.administrativeLevels.level2long = result.address_components[i].long_name;
+          extractedObj.administrativeLevels.level2short = result.address_components[i].short_name;
+          break;
+        //Administrative Level 3
+        case 'administrative_area_level_3':
+          extractedObj.administrativeLevels.level3long = result.address_components[i].long_name;
+          extractedObj.administrativeLevels.level3short = result.address_components[i].short_name;
+          break;
+        //Administrative Level 4
+        case 'administrative_area_level_4':
+          extractedObj.administrativeLevels.level4long = result.address_components[i].long_name;
+          extractedObj.administrativeLevels.level4short = result.address_components[i].short_name;
+          break;
+        //Administrative Level 5
+        case 'administrative_area_level_5':
+          extractedObj.administrativeLevels.level5long = result.address_components[i].long_name;
+          extractedObj.administrativeLevels.level5short = result.address_components[i].short_name;
+          break;
+        // City
+        case 'locality':
+          extractedObj.city = result.address_components[i].long_name;
+          break;
+        // Address
+        case 'postal_code':
+          extractedObj.zipcode = result.address_components[i].long_name;
+          break;
+        case 'route':
+          extractedObj.streetName = result.address_components[i].long_name;
+          break;
+        case 'street_number':
+          extractedObj.streetNumber = result.address_components[i].long_name;
+          break;
+        case 'premise':
+          extractedObj.extra.premise = result.address_components[i].long_name;
+          break;
+        case 'subpremise':
+          extractedObj.extra.subpremise = result.address_components[i].long_name;
+          break;
+        case 'establishment':
+          extractedObj.extra.establishment = result.address_components[i].long_name;
+          break;
+        case 'sublocality_level_1':
+        case 'political':
+        case 'sublocality':
+        case 'neighborhood':
+          if(!extractedObj.extra.neighborhood) {
+            extractedObj.extra.neighborhood = result.address_components[i].long_name;
+          }
+          break;
+      }
     }
   }
   return extractedObj;

--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -219,6 +219,7 @@ GoogleGeocoder.prototype._formatResult = function (result) {
           break;
         // City
         case 'locality':
+        case 'postal_town':
           extractedObj.city = result.address_components[i].long_name;
           break;
         // Address


### PR DESCRIPTION
Google often pushes "locality" as as the non-zero element of the "types" array when a city name has colloquial usage (in addition to its other uses, such as a locality). This was causing the library not to find the city amongst the Google results for several major cities such as Sydney, Australia, which Google returns as:

         "address_components" : [
            {
               "long_name" : "Sydney",
               "short_name" : "Sydney",
               "types" : [ "colloquial_area", "locality", "political" ]
            },
            {
               "long_name" : "New South Wales",
               "short_name" : "NSW",
               "types" : [ "administrative_area_level_1", "political" ]
            },
            {
               "long_name" : "Australia",
               "short_name" : "AU",
               "types" : [ "country", "political" ]
            }
         ]

This pull request simply has the library look at all the different types of each address component when searching for the components it recognizes (such as locality which maps to "city). This fixes the missing "city" results for Sydney, Australia and many other cities where colloquial_area was being added to the front of the "types" array by Google.