### PR TITLE
Yandex — Latitude and longitude are reversed

### DIFF
--- a/lib/geocoder/yandexgeocoder.js
+++ b/lib/geocoder/yandexgeocoder.js
@@ -40,8 +40,8 @@ function _formatResult(result) {
   result = result.GeoObject.metaDataProperty.GeocoderMetaData.AddressDetails;
 
   return {
-    'latitude' : position[0],
-    'longitude' : position[1],
+    'latitude' : position[1],
+    'longitude' : position[0],
     'city' : _findKey(result, 'LocalityName'),
     'state' : _findKey(result, 'AdministrativeAreaName'),
     'streetName': _findKey(result, 'ThoroughfareName'),


### PR DESCRIPTION
Latitude and longitude are reversed for Yandex geocoder.

Check this — `Moscow, Russia` query rusults:

For Yandex:
```
latitude:"37.617635"
longitude:"55.755814"
city:"Москва"
state:"Москва"
streetName:null
streetNumber:null
countryCode:"RU"
country:"Россия"
provider:"yandex"
```

For OpenStreetMap:

```
latitude:55.7507178
longitude:37.6176606
country:"РФ"
city:"Москва"
state:"Москва"
countryCode:"RU"
provider:"openstreetmap"
```

For Google:
```
formattedAddress:"Moscow, Russia"
latitude:55.755826
longitude:37.6172999
city:"Moscow"
country:"Russia"
countryCode:"RU"
provider:"google"
```