### PR TITLE
Yandex: return float lat/lng instead of string

### DIFF
--- a/lib/geocoder/yandexgeocoder.js
+++ b/lib/geocoder/yandexgeocoder.js
@@ -40,8 +40,8 @@ function _formatResult(result) {
   result = result.GeoObject.metaDataProperty.GeocoderMetaData.AddressDetails;
 
   return {
-    'latitude' : position[1],
-    'longitude' : position[0],
+    'latitude' : parseFloat(position[1]),
+    'longitude' : parseFloat(position[0]),
     'city' : _findKey(result, 'LocalityName'),
     'state' : _findKey(result, 'AdministrativeAreaName'),
     'streetName': _findKey(result, 'ThoroughfareName'),

--- a/test/geocoder/yandexgeocoder.js
+++ b/test/geocoder/yandexgeocoder.js
@@ -55,8 +55,8 @@ describe('YandexGeocoder', function() {
             err.should.to.equal(false);
 
             results[0].should.to.deep.equal({
-                'latitude': '40.653388',
-                'longitude': '-73.944050',
+                'latitude': 40.653388,
+                'longitude': -73.944050,
                 'country': 'United States',
                 'city': 'New York',
                 'state' : 'New York',
@@ -197,8 +197,8 @@ describe('YandexGeocoder', function() {
           'city': 'Собинка',
           'country': 'Россия',
           'countryCode': 'RU',
-          'latitude': '55.98507',
-          'longitude': '40.018571',
+          'latitude': 55.98507,
+          'longitude': 40.018571,
           'state': 'Владимирская область',
           'streetName': 'Центральная улица',
           'streetNumber': '15',


### PR DESCRIPTION
The latitude and longitude from Yandex geocoding result are string,
while I expected to get float numbers (like google geocoding result).