### PR TITLE
added place_id support to google geocoder

### DIFF
--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -261,14 +261,17 @@ GoogleGeocoder.prototype._formatResult = function (result) {
  * @param <function> callback Callback method
  */
 GoogleGeocoder.prototype._reverse = function (query, callback) {
-  var lat = query.lat;
-  var lng = query.lon;
 
   var _this = this;
   var params = this._prepareQueryString();
 
-  params.latlng = lat + ',' + lng;
-
+  if(query.lat&&query.lon) {
+    params.latlng = query.lat + ',' + query.lon;
+  }
+  else if(query.place_id ) {
+    params.place_id = query.place_id ;
+  }
+  
   if (query.language) {
     params.language = query.language;
   }


### PR DESCRIPTION
[Google has place_id support in its geocoder](https://developers.google.com/maps/documentation/geocoding/intro#reverse-restricted)
So I added it in accordance with the official [google api](https://developers.google.com/maps/documentation/geocoding/intro#reverse-restricted)
and left lat/lon support intact.

it will give priority to lat/lon , but if lat/lon is empty, it will check if you sent the place_id variable.

why do I need place_id?
because apis such as [google places autocomplete](https://developers.google.com/places/web-service/autocomplete#place_autocomplete_responses)
Do not return lat/lon rather simpley a place_id.

Thank you!




