### PR TITLE
fix bug with object address

### DIFF
--- a/lib/geocoder/abstractgeocoder.js
+++ b/lib/geocoder/abstractgeocoder.js
@@ -58,18 +58,22 @@ AbstractGeocoder.prototype.reverse = function(query, callback) {
 * @param <function> callback Callback method
 */
 AbstractGeocoder.prototype.geocode = function(value, callback) {
+  var address = value
+  if (typeof value === 'object') {
+    address = value.address
+  }
   if (typeof this._geocode != 'function') {
     throw new ValueError(this.constructor.name + ' does not support geocoding');
   }
-  if (net.isIPv4(value) && (!this.supportIPv4 || this.supportIPv4 == 'undefined')) {
+  if (net.isIPv4(address) && (!this.supportIPv4 || this.supportIPv4 == 'undefined')) {
     throw new ValueError(this.constructor.name + ' does not support geocoding IPv4');
   }
 
-  if (net.isIPv6(value) && (!this.supportIPv6 || this.supportIPv6 == 'undefined')) {
+  if (net.isIPv6(address) && (!this.supportIPv6 || this.supportIPv6 == 'undefined')) {
     throw new ValueError(this.constructor.name + ' does not support geocoding IPv6');
   }
 
-  if (this.supportAddress === false && (!net.isIPv4(value) && !net.isIPv6(value))) {
+  if (this.supportAddress === false && (!net.isIPv4(address) && !net.isIPv6(address))) {
     throw new ValueError(this.constructor.name + ' does not support geocoding address');
   }
 


### PR DESCRIPTION
If use object for request in geocode method get error:

```
TypeError: Cannot convert object to primitive value
    at GoogleGeocoder.AbstractGeocoder.geocode (/home/enniel/Code/api-server/node_modules/node-geocoder/lib/geocoder/abstractgeocoder.js:64:11)
    at Proxy.<anonymous> (/home/enniel/Code/api-server/node_modules/node-geocoder/lib/geocoder.js:25:24)
```
This code don`t workded:
```
const Geocoder = geocoder(config)
Geocoder.geocode({ address: '29 Av. des Champs-Élysées, 75008 Paris, France' })
```
This code worked:
```
const Geocoder = geocoder(config)
Geocoder.geocode('29 Av. des Champs-Élysées, 75008 Paris, France')
```