### PR TITLE
Add SSL to API endpoint (open.mapquestapi.com)

### DIFF
--- a/lib/geocoder/openmapquestgeocoder.js
+++ b/lib/geocoder/openmapquestgeocoder.js
@@ -15,7 +15,7 @@ var MapQuestGeocoder = function OpenMapQuestGeocoder(httpAdapter, apiKey) {
   }
 
   this.apiKey = apiKey;
-  this._endpoint = 'http://open.mapquestapi.com/geocoding/v1';
+  this._endpoint = 'https://open.mapquestapi.com/geocoding/v1';
 };
 
 util.inherits(MapQuestGeocoder, AbstractGeocoder);


### PR DESCRIPTION
- See API documentation at: https://developer.mapquest.com/documentation/geocoding-api/
- And a separate in-browser test with SSL and an API key works.