### PR TITLE
Add SSL to API endpoint (dev.virtualearth.net)

### DIFF
--- a/lib/geocoder/virtualearth.js
+++ b/lib/geocoder/virtualearth.js
@@ -18,7 +18,7 @@ var VirtualEarthGeocoder = function VirtualEarthGeocoder(httpAdapter, options) {
 util.inherits(VirtualEarthGeocoder, AbstractGeocoder);
 
 // TomTom geocoding API endpoint
-VirtualEarthGeocoder.prototype._endpoint = 'http://dev.virtualearth.net/REST/v1/Locations';
+VirtualEarthGeocoder.prototype._endpoint = 'https://dev.virtualearth.net/REST/v1/Locations';
 
 /**
 * Geocode


### PR DESCRIPTION
- See API documentation: https://msdn.microsoft.com/en-us/library/dn948525.aspx
- HTTPS is open, see: https://dev.virtualearth.net/REST/V1/GeospatialEndpoint/language/userRegion?key=some_api_key