### PR TITLE
Add SSL to API endpoint (freegeoip.net)

### DIFF
--- a/lib/geocoder/freegeoipgeocoder.js
+++ b/lib/geocoder/freegeoipgeocoder.js
@@ -14,7 +14,7 @@ var FreegeoipGeocoder = function FreegeoipGeocoder(httpAdapter) {
 util.inherits(FreegeoipGeocoder, AbstractGeocoder);
 
 // WS endpoint
-FreegeoipGeocoder.prototype._endpoint = 'http://freegeoip.net/json/';
+FreegeoipGeocoder.prototype._endpoint = 'https://freegeoip.net/json/';
 
 /**
 * Geocode


### PR DESCRIPTION
- See it live: https://freegeoip.net/json/
- Remark: FreeGeoIP will be deprecated as of July 1st, 2018. For more information, see: 
https://github.com/apilayer/freegeoip#readme