### PR TITLE
Add SSL to API endpoint (api.geocod.io)

### DIFF
--- a/lib/geocoder/geocodiogeocoder.js
+++ b/lib/geocoder/geocodiogeocoder.js
@@ -15,7 +15,7 @@ var GeocodioGeocoder = function GeocodioGeocoder(httpAdapter, apiKey) {
   }
 
   this.apiKey = apiKey;
-  this._endpoint = 'http://api.geocod.io/v1';
+  this._endpoint = 'https://api.geocod.io/v1';
 };
 
 util.inherits(GeocodioGeocoder, AbstractGeocoder);


### PR DESCRIPTION
- See the documentation: https://geocod.io/docs/
- Live in-browser test: https://api.geocod.io/v1/geocode?q=1109+N+Highland+St%2c+Arlington+VA&api_key=API_KEY