### PR TITLE
Add SSL to API endpoint (mapquestapi.com)

### DIFF
--- a/lib/geocoder/mapquestgeocoder.js
+++ b/lib/geocoder/mapquestgeocoder.js
@@ -19,7 +19,7 @@ var MapQuestGeocoder = function MapQuestGeocoder(httpAdapter, apiKey) {
 
 util.inherits(MapQuestGeocoder, AbstractGeocoder);
 
-MapQuestGeocoder.prototype._endpoint = 'http://www.mapquestapi.com/geocoding/v1';
+MapQuestGeocoder.prototype._endpoint = 'https://www.mapquestapi.com/geocoding/v1';
 
 /**
 * Geocode


### PR DESCRIPTION
- See it live: https://developer.mapquest.com/documentation/samples/geocoding/v1/address/