### PR TITLE
LocationIQ: Only uppercase the country code if it is set

### DIFF
--- a/lib/geocoder/locationiqgeocoder.js
+++ b/lib/geocoder/locationiqgeocoder.js
@@ -132,8 +132,14 @@ LocationIQGeocoder.prototype._formatResult = function(result) {
     transformedResult.zipcode = result.address.postcode;
     transformedResult.streetName = result.address.road || result.address.cycleway;
     transformedResult.streetNumber = result.address.house_number;
+    
     // make sure countrycode is always uppercase to keep node-geocoder api formats
-    transformedResult.countryCode = result.address.country_code.toUpperCase();
+    var countryCode = result.address.country_code;
+    if (countryCode) {
+        countryCode = countryCode.toUpperCase();
+    }
+    
+    transformedResult.countryCode = countryCode;
   }
   return transformedResult;
 };


### PR DESCRIPTION
Analogous to the [OSM geocoder code](https://github.com/nchaulet/node-geocoder/blob/master/lib/geocoder/openstreetmapgeocoder.js#L71-L74) I changed the code of the LocationIQ Geocoder to only uppercase the country code of the address, if one exists. 