### PR TITLE
Add support for no_annotations to open cage provider

### DIFF
--- a/lib/geocoder/opencagegeocoder.js
+++ b/lib/geocoder/opencagegeocoder.js
@@ -155,6 +155,10 @@ OpenCageGeocoder.prototype._getCommonParams = function () {
     params.language = this.options.language;
   }
 
+  if (typeof this.options.noAnnotations !== 'undefined') {
+    params.no_annotations = this.options.noAnnotations;
+  }
+
   return params;
 };
 

--- a/lib/geocoder/virtualearth.js
+++ b/lib/geocoder/virtualearth.js
@@ -63,7 +63,7 @@ VirtualEarthGeocoder.prototype._reverse = function(value, callback) {
     key: this.options.apiKey
   };
 
-  var endpoint = this._endpoint + "/" + value.lat + "," + value.lon;
+  var endpoint = this._endpoint + '/' + value.lat + ',' + value.lon;
 
   this.httpAdapter.get(endpoint, params, function(err, result) {
     if (err) {

--- a/test/geocoder/mapquestgeocoder.test.js
+++ b/test/geocoder/mapquestgeocoder.test.js
@@ -60,7 +60,7 @@
 
                 var mock = sinon.mock(mockedHttpAdapter);
                 mock.expects('get').withArgs(
-                    'http://www.mapquestapi.com/geocoding/v1/address',
+                    'https://www.mapquestapi.com/geocoding/v1/address',
                     { key: "API_KEY", location: "test" }
                 ).once().returns({then: function() {}});
 

--- a/test/geocoder/opencagegeocoder.test.js
+++ b/test/geocoder/opencagegeocoder.test.js
@@ -68,6 +68,25 @@
 
             });
 
+            test('Should make a request with no_annotations option', () => {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').withArgs('http://api.opencagedata.com/geocode/v1/json', {
+                    key: 'API_KEY',
+                    q: '1 champs élysée Paris',
+                    no_annotations: 1,
+                }).once().returns({then: function (err,result) {}});
+
+                var ocgAdapter = new OpenCageGeocoder(mockedHttpAdapter, 'API_KEY', {
+                    noAnnotations: 1
+                });
+
+                ocgAdapter.geocode('1 champs élysée Paris');
+
+                mock.verify();
+
+            });
+
             test(
                 'Should call httpAdapter get method with components if called with object',
                 () => {
@@ -215,10 +234,29 @@
                     done();
                 });
             });
-
         });
 
         describe('#reverse' , () => {
+
+            test('Should make a request with no_annotations option', () => {
+
+                var mock = sinon.mock(mockedHttpAdapter);
+                mock.expects('get').withArgs('http://api.opencagedata.com/geocode/v1/json', {
+                    key: 'API_KEY',
+                    q: '13.3826786867678 52.51921145',
+                    no_annotations: 1,
+                }).once().returns({then: function (err,result) {}});
+
+                var ocgAdapter = new OpenCageGeocoder(mockedHttpAdapter, 'API_KEY', {
+                    noAnnotations: 1
+                });
+
+                ocgAdapter.reverse({lat:13.3826786867678, lon:52.51921145});
+
+                mock.verify();
+
+            });
+
             test('Should return geocoded address', done => {
                 var mock = sinon.mock(mockedHttpAdapter);
                 mock.expects('get').once().callsArgWith(2, false, {


### PR DESCRIPTION
I'm planning on making a significant number of requests to OpenCage's geocoding service, and it's recommended that we pass `no_annotations=1` so that we can speed up response times and minimize payloads by excluding [annotations](url
https://opencagedata.com/api#annotations) data.

I've added tests and checked the linter. In the process I realized that2 of the MapQuest geocoder tests are failing and the VirtualEarth geocoder creates linter warnings. Those were preexisting issues and were unaffected by my changes, but I took the liberty of fixing those as well so that these changes comply with the contributor guidelines.