### PR TITLE
Updated tomtom geocoder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ var geocoder = NodeGeocoder({
   * For `geocode` function you should use an object where `{lat, lon}` are required parameters. Additional parameters like `zoom` are available, see details in [Reverse Geocoding Reference](https://pickpoint.io/api-reference#reverse-geocoding).
 * `smartyStreet`: Smarty street geocoder (US only), you need to specify `options.auth_id` and `options.auth_token`
 * `teleport`: Teleport supports city and urban area forward and reverse geocoding; for more information, see [Teleport API documentation](https://developers.teleport.org/api/)
-* `tomtom`: TomTomGeocoder. Supports address geocoding. You need to specify `options.apiKey`
+* `tomtom`: TomTomGeocoder. Supports address geocoding. You need to specify `options.apiKey` and can use `options.language` to specify a language 
 * `virtualearth`: VirtualEarthGeocoder (Bing maps). Supports address geocoding. You need to specify `options.apiKey`
 * `yandex`: Yandex support address geocoding, you can use `options.language` to specify language
 

--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -30,8 +30,7 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
   var _this = this;
 
   var params = {
-    key   : this.options.apiKey,
-    limit: 1
+    key   : this.options.apiKey
   };
 
   if (this.options.language) {

--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -37,7 +37,7 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
     params.language = this.options.language;
   }
 
-  var url = this._endpoint + '/' + value + '.json';
+  var url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
 
   this.httpAdapter.get(url, params, function(err, result) {
     if (err) {

--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -18,8 +18,7 @@ var TomTomGeocoder = function TomTomGeocoder(httpAdapter, options) {
 util.inherits(TomTomGeocoder, AbstractGeocoder);
 
 // TomTom geocoding API endpoint
-TomTomGeocoder.prototype._endpoint = 'https://api.tomtom.com/lbs/geocoding/geocode';
-// 
+TomTomGeocoder.prototype._endpoint = 'https://api.tomtom.com/search/2/geocode';
 
 /**
 * Geocode
@@ -31,19 +30,24 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
   var _this = this;
 
   var params = {
-    query : value,
     key   : this.options.apiKey,
-    format: 'json'
+    limit: 1
   };
 
-  this.httpAdapter.get(this._endpoint, params, function(err, result) {
+  if (this.options.language) {
+    params.language = this.options.language;
+  }
+
+  var url = this._endpoint + '/' + value + '.json';
+
+  this.httpAdapter.get(url, params, function(err, result) {
     if (err) {
       return callback(err);
     } else {
       var results = [];
 
-      for(var i = 0; i < result.geoResponse.geoResult.length; i++) {
-          results.push(_this._formatResult(result.geoResponse.geoResult[i]));
+      for(var i = 0; i < result.results.length; i++) {
+          results.push(_this._formatResult(result.results[i]));
       }
 
       results.raw = result;
@@ -54,15 +58,15 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
 
 TomTomGeocoder.prototype._formatResult = function(result) {
   return {
-    'latitude' : result.latitude,
-    'longitude' : result.longitude,
-    'country' : result.country,
-    'city' : result.city,
-    'state' : result.state,
-    'zipcode' : result.postcode,
-    'streetName': result.street,
-    'streetNumber' : result.houseNumber,
-    'countryCode' : result.countryISO3
+    'latitude' : result.position.lat,
+    'longitude' : result.position.lon,
+    'country' : result.address.country,
+    'city' : result.address.localName,
+    'state' : result.address.countrySubdivision,
+    'zipcode' : result.address.postcode,
+    'streetName': result.address.streetName,
+    'streetNumber' : result.address.streetNumber,
+    'countryCode' : result.address.countryCode
   };
 };
 


### PR DESCRIPTION
Pull request will update the TomTom geocoder API url and handle the new API response.
Related to ticket: #272 

Please review the code (it does work for my use) but I was not sure why countrycode returned an countryISO3 before. Although it is available on the new API, I assume a normal countrycode is prefered. Also added a hardcoded limit but not sure how this is for the other geocoder libs. The rest should be ok.