### PR TITLE
Make sure to assign `production` option in the HERE geocoder constructor

### DIFF
--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -59,7 +59,7 @@ var GeocoderFactory = {
       return new GoogleGeocoder(adapter, {clientId: extra.clientId, apiKey: extra.apiKey, language: extra.language, region: extra.region, excludePartialMatches: extra.excludePartialMatches, channel: extra.channel});
     }
     if (geocoderName === 'here') {
-      return new HereGeocoder(adapter, {appId: extra.appId, appCode: extra.appCode, language: extra.language, politicalView: extra.politicalView, country: extra.country, state: extra.state});
+      return new HereGeocoder(adapter, {appId: extra.appId, appCode: extra.appCode, language: extra.language, politicalView: extra.politicalView, country: extra.country, state: extra.state, production: extra.production});
     }
     if (geocoderName === 'agol') {
       return new AGOLGeocoder(adapter, {client_id: extra.client_id, client_secret: extra.client_secret});


### PR DESCRIPTION
Addendum to #279 
Completely missed this the first time around. When I updated the tests, I believe I was accessing the HereGeocoder constructor directly, thus obscuring this bug.

Sorry that I didn't catch this before a release was pushed. 

---

Perhaps simply passing in `extra` to the second constructor argument would prevent this mistake in the future?