### PR TITLE
apiKey support for yandex is implemented

### DIFF
--- a/lib/geocoder/yandexgeocoder.js
+++ b/lib/geocoder/yandexgeocoder.js
@@ -9,6 +9,7 @@ var AbstractGeocoder = require('./abstractgeocoder');
  * @param <object> options     Options (language, clientId, apiKey)
  */
 var YandexGeocoder = function YandexGeocoder(httpAdapter, options) {
+  this.options = ['apiKey'];
   YandexGeocoder.super_.call(this, httpAdapter, options);
 };
 
@@ -87,6 +88,10 @@ function _processOptionsToParams(params, options){
   //Limit search in bbox (1) or not limit (0)
   if (options.rspn) {
     params.rspn = options.rspn;
+  }
+
+  if(options.apiKey) {
+    params.apikey = options.apiKey;
   }
 }
 

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -90,6 +90,7 @@ var GeocoderFactory = {
     }
     if (geocoderName === 'yandex') {
       return new YandexGeocoder(adapter, {
+        apiKey: extra.apiKey,
         language: extra.language,
         results: extra.results,
         skip:  extra.skip,


### PR DESCRIPTION
The current release doesn't add apiKey to yandex request and return 403 Forbidden as result. The patch is solves this issue.