### PR TITLE
Fix Agolgeocoder JSON conversion from httpadapter

### DIFF
--- a/lib/geocoder/agolgeocoder.js
+++ b/lib/geocoder/agolgeocoder.js
@@ -119,7 +119,6 @@ AGOLGeocoder.prototype.geocode = function(value, callback) {
     };
 
     _this.httpAdapter.get(_this._endpoint, params, function(err, result) {
-      result = JSON.parse(result);
         if (err) {
           return callback(err);
         } else {

--- a/test/geocoder/agolgeocoder.test.js
+++ b/test/geocoder/agolgeocoder.test.js
@@ -143,7 +143,7 @@ describe('AGOLGeocoder', () => {
       var mock = sinon.mock(mockedRequestifyAdapter);
 
       mock.expects('get').once().callsArgWith(2, false,
-        '{"spatialReference":{"wkid":4326,"latestWkid":4326},"locations":[{"name":"380 New York St, Redlands, California, 92373","extent":{"xmin":-117.196701,"ymin":34.055489999999999,"xmax":-117.19470099999999,"ymax":34.057490000000001},"feature":{"geometry":{"x":-117.19566584280369,"y":34.056490727765947},"attributes":{"AddNum":"380","StPreDir":"","StName":"New York","StType":"St","City":"Redlands","Postal":"92373","Region":"California","Country":"USA"}}}]}'
+        JSON.parse('{"spatialReference":{"wkid":4326,"latestWkid":4326},"locations":[{"name":"380 New York St, Redlands, California, 92373","extent":{"xmin":-117.196701,"ymin":34.055489999999999,"xmax":-117.19470099999999,"ymax":34.057490000000001},"feature":{"geometry":{"x":-117.19566584280369,"y":34.056490727765947},"attributes":{"AddNum":"380","StPreDir":"","StName":"New York","StType":"St","City":"Redlands","Postal":"92373","Region":"California","Country":"USA"}}}]}')
         );
       var geocoder = new AGOLGeocoder(mockedRequestifyAdapter,mockedOptions);
 
@@ -174,7 +174,7 @@ describe('AGOLGeocoder', () => {
       var mock = sinon.mock(mockedRequestifyAdapter);
 
       mock.expects('get').once().callsArgWith(2, false,
-        '{"error":{"code":498,"message":"Invalid Token","details":[]}}'
+        JSON.parse('{"error":{"code":498,"message":"Invalid Token","details":[]}}')
         );
       var geocoder = new AGOLGeocoder(mockedRequestifyAdapter,mockedOptions);
 


### PR DESCRIPTION
## What
This PR removes the double conversion of JSON strings from the request response to ARCGIS queries.
It also updates it's tests to a valid-passing status.

## Why
**Running the example:**
```ts
import NodeGeocoder from 'node-geocoder';

import { ARCGIS_CLIENT_ID, ARCGIS_CLIENT_SECRET } from './config';

var options: NodeGeocoder.AgolOptions = {
  provider: 'agol',
  client_id: ARCGIS_CLIENT_ID,
  client_secret: ARCGIS_CLIENT_SECRET,
};

var geocoder = NodeGeocoder(options);

// Using callback
geocoder.geocode('29 champs elysée paris', function(err: any, res: any) {
  console.log(res);
});

// Or using Promise
geocoder
  .geocode('29 champs elysée paris')
  .then(function(res: any) {
    console.log(res);
  })
  .catch(function(err: any) {
    console.log(err);
  });
```
**Throws error** 
```sh
SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
    at C:\Users\USERNAME\ra-map\node_modules\node-geocoder\lib\geocoder\agolgeocoder.js:122:21
    at IncomingMessage.<anonymous> (C:\Users\jaepe\ra-map\node_modules\node-geocoder\lib\httpadapter\httpadapter.js:66:9)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:421:20)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:114:19)
```

**Which is caused by:**

`lib\geocoder\agolgeocoder.js`
```js
    _this.httpAdapter.get(_this._endpoint, params, function(err, result) {
      result = JSON.parse(result);
```
**And**

`lib\httpadapter\httpadapter.js`
```js
      if (contentType !== undefined && contentType.indexOf('application/json') >= 0) {
        callback(false, JSON.parse(str));
      } else {
        callback(false, str);
      }
```

**Which is due to the header response from ARCGIS:**
` 'content-type': 'application/json;`

```txt
{ date: 'Tue, 17 Dec 2019 16:17:24 GMT',
  'content-type': 'application/json;charset=UTF-8',
  'content-length': '500',
  connection: 'close',
  'x-content-type-options': 'nosniff',
  'x-xss-protection': '1; mode=block',
  server: '',
  etag: '54b33e50',
  'cache-control': 'max-age=300',
  'x-cached': 'HIT',
  vary: 'Origin,Accept-Encoding' }
```