### PR TITLE
Allow passing of limit parameter to opendatafrance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-geocoder",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "description": "Node Geocoder, node geocoding library, supports google maps, mapquest, open street map, tom tom, promise",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently the OpenDataFrance always requests 20 records at a time via `limit`. Turns out we don't need to set a `limit` at all - the API defaults to 5 without the parameter being set - and with this addition we can pass our own custom limit in.

