### PR TITLE
Fix HERE geocoder endpoints for appCode authentication

### DIFF
--- a/lib/geocoder/heregeocoder.js
+++ b/lib/geocoder/heregeocoder.js
@@ -7,14 +7,13 @@ const OPTIONS = [
   'language',
   'politicalView',
   'country',
-  'state',
-  'production'
+  'state'
 ];
 
 /**
  * Constructor
  * @param <object> httpAdapter Http Adapter
- * @param <object> options     Options (appId, appCode, language, politicalView, country, state, production)
+ * @param <object> options     Options (appId, appCode, language, politicalView, country, state)
  */
 class HereGeocoder extends AbstractGeocoder {
   constructor(httpAdapter, options) {
@@ -211,11 +210,9 @@ Object.defineProperties(HereGeocoder.prototype, {
   _geocodeEndpoint: {
     get: function() {
       return (
-        this.options.apiKey ? 'https://geocoder.ls.hereapi.com/6.2/geocode.json' :
-        (
-          this.options.production ? 'https://geocoder.api.here.com/6.2/geocode.json' :
-          'https://geocoder.cit.api.here.com/6.2/geocode.json'
-        )
+        this.options.apiKey ?
+          'https://geocoder.ls.hereapi.com/6.2/geocode.json' :
+          'https://geocoder.api.here.com/6.2/geocode.json'
       );
     }
   },
@@ -224,11 +221,9 @@ Object.defineProperties(HereGeocoder.prototype, {
   _reverseEndpoint: {
     get: function() {
       return (
-        this.options.apiKey ? 'https://geocoder.ls.hereapi.com/6.2/reversegeocode.json' :
-        (
-          this.options.production ? 'https://geocoder.api.here.com/6.2/reversegeocode.json' :
-          'https://geocoder.cit.api.here.com/6.2/reversegeocode.json'
-        )
+        this.options.apiKey ?
+          'https://geocoder.ls.hereapi.com/6.2/reversegeocode.json' :
+          'https://geocoder.api.here.com/6.2/reversegeocode.json'
       );
     }
   }

--- a/lib/geocoder/heregeocoder.js
+++ b/lib/geocoder/heregeocoder.js
@@ -222,8 +222,8 @@ Object.defineProperties(HereGeocoder.prototype, {
     get: function() {
       return (
         this.options.apiKey ?
-          'https://geocoder.ls.hereapi.com/6.2/reversegeocode.json' :
-          'https://geocoder.api.here.com/6.2/reversegeocode.json'
+          'https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json' :
+          'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json'
       );
     }
   }

--- a/lib/geocoder/heregeocoder.js
+++ b/lib/geocoder/heregeocoder.js
@@ -210,14 +210,26 @@ Object.defineProperties(HereGeocoder.prototype, {
   // Here geocoding API endpoint
   _geocodeEndpoint: {
     get: function() {
-      return 'https://geocoder.ls.hereapi.com/6.2/geocode.json';
+      return (
+        this.options.apiKey ? 'https://geocoder.ls.hereapi.com/6.2/geocode.json' :
+        (
+          this.options.production ? 'https://geocoder.api.here.com/6.2/geocode.json' :
+          'https://geocoder.cit.api.here.com/6.2/geocode.json'
+        )
+      );
     }
   },
 
   // Here reverse geocoding API endpoint
   _reverseEndpoint: {
     get: function() {
-      return 'https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json';
+      return (
+        this.options.apiKey ? 'https://geocoder.ls.hereapi.com/6.2/reversegeocode.json' :
+        (
+          this.options.production ? 'https://geocoder.api.here.com/6.2/reversegeocode.json' :
+          'https://geocoder.cit.api.here.com/6.2/reversegeocode.json'
+        )
+      );
     }
   }
 });

--- a/test/geocoder/heregeocoder.test.js
+++ b/test/geocoder/heregeocoder.test.js
@@ -58,7 +58,7 @@
           'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json'
         );
       });
-      
+
       test('Should use ls endpoint when using apiKey', () => {
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
           apiKey: 'API_KEY'
@@ -102,8 +102,7 @@
           .expects('get')
           .withArgs('https://geocoder.ls.hereapi.com/6.2/geocode.json', {
             searchtext: '1 champs élysée Paris',
-            app_code: 'APP_CODE',
-            app_id: 'APP_ID',
+            apiKey: 'API_KEY',
             additionaldata: 'Country2,true',
             gen: 8
           })
@@ -111,8 +110,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.geocode('1 champs élysée Paris');
@@ -127,8 +125,7 @@
           .withArgs('https://geocoder.ls.hereapi.com/6.2/geocode.json', {
             searchtext: '1 champs élysée Paris',
             language: 'en',
-            app_code: 'APP_CODE',
-            app_id: 'APP_ID',
+            apiKey: 'API_KEY',
             additionaldata: 'Country2,true',
             gen: 8
           })
@@ -136,8 +133,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE',
+          apiKey: 'API_KEY',
           language: 'en'
         });
 
@@ -153,8 +149,7 @@
           .withArgs('https://geocoder.ls.hereapi.com/6.2/geocode.json', {
             searchtext: '1 champs élysée Paris',
             politicalview: 'GRE',
-            app_code: 'APP_CODE',
-            app_id: 'APP_ID',
+            apiKey: 'API_KEY',
             additionaldata: 'Country2,true',
             gen: 8
           })
@@ -162,8 +157,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE',
+          apiKey: 'API_KEY',
           politicalView: 'GRE'
         });
 
@@ -179,8 +173,7 @@
           .withArgs('https://geocoder.ls.hereapi.com/6.2/geocode.json', {
             searchtext: '1 champs élysée Paris',
             country: 'FR',
-            app_code: 'APP_CODE',
-            app_id: 'APP_ID',
+            apiKey: 'API_KEY',
             additionaldata: 'Country2,true',
             gen: 8
           })
@@ -188,8 +181,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE',
+          apiKey: 'API_KEY',
           country: 'FR'
         });
 
@@ -205,8 +197,7 @@
           .withArgs('https://geocoder.ls.hereapi.com/6.2/geocode.json', {
             searchtext: '1 champs élysée Paris',
             state: 'Île-de-France',
-            app_code: 'APP_CODE',
-            app_id: 'APP_ID',
+            apiKey: 'API_KEY',
             additionaldata: 'Country2,true',
             gen: 8
           })
@@ -214,8 +205,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE',
+          apiKey: 'API_KEY',
           state: 'Île-de-France'
         });
 
@@ -232,8 +222,7 @@
             searchtext: '1 champs élysée Paris',
             country: 'FR',
             postalcode: '75008',
-            app_code: 'APP_CODE',
-            app_id: 'APP_ID',
+            apiKey: 'API_KEY',
             additionaldata: 'Country2,true',
             gen: 8
           })
@@ -241,8 +230,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.geocode({
@@ -261,8 +249,7 @@
           .withArgs('https://geocoder.ls.hereapi.com/6.2/geocode.json', {
             searchtext: 'Kaiserswerther Str 10, Berlin',
             country: 'DE',
-            app_code: 'APP_CODE',
-            app_id: 'APP_ID',
+            apiKey: 'API_KEY',
             additionaldata: 'Country2,true',
             gen: 8
           })
@@ -270,8 +257,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE',
+          apiKey: 'API_KEY',
           country: 'FR',
           state: 'Île-de-France'
         });
@@ -348,8 +334,7 @@
             }
           });
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.geocode('Kaiserswerther Str 10, Berlin', function(
@@ -456,8 +441,7 @@
           });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.geocode('1 champs élysées Paris', function(err, results) {
@@ -488,8 +472,7 @@
           });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.geocode('1 champs élysées Paris', function(err, results) {
@@ -519,8 +502,7 @@
           .returns({ then: function() {} });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.reverse({ lat: 10.0235, lon: -2.3662 });
@@ -608,8 +590,7 @@
           });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.reverse({ lat: 40.714232, lon: -73.9612889 }, function(
@@ -733,8 +714,7 @@
           });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.reverse({ lat: 40.714232, lon: -73.9612889 }, function(
@@ -768,8 +748,7 @@
           });
 
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE'
+          apiKey: 'API_KEY',
         });
 
         hereAdapter.reverse({ lat: 40.714232, lon: -73.9612889 }, function(

--- a/test/geocoder/heregeocoder.test.js
+++ b/test/geocoder/heregeocoder.test.js
@@ -45,25 +45,23 @@
         hereAdapter.should.be.instanceof(HereGeocoder);
       });
 
-      test('Should use CIT endpoint, if production is not provided', () => {
+      test('Should use api endpoint when using appCode', () => {
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
           appId: 'APP_ID',
           appCode: 'APP_CODE'
         });
 
         hereAdapter._geocodeEndpoint.should.equal(
-          'https://geocoder.ls.hereapi.com/6.2/geocode.json'
+          'https://geocoder.api.hereapi.com/6.2/geocode.json'
         );
         hereAdapter._reverseEndpoint.should.equal(
-          'https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json'
+          'https://reverse.geocoder.api.hereapi.com/6.2/reversegeocode.json'
         );
       });
-
-      test('Should use production endpoint, if production is provided', () => {
+      
+      test('Should use ls endpoint when using apiKey', () => {
         var hereAdapter = new HereGeocoder(mockedHttpAdapter, {
-          appId: 'APP_ID',
-          appCode: 'APP_CODE',
-          production: true
+          apiKey: 'API_KEY'
         });
 
         hereAdapter._geocodeEndpoint.should.equal(

--- a/test/geocoder/heregeocoder.test.js
+++ b/test/geocoder/heregeocoder.test.js
@@ -52,10 +52,10 @@
         });
 
         hereAdapter._geocodeEndpoint.should.equal(
-          'https://geocoder.api.hereapi.com/6.2/geocode.json'
+          'https://geocoder.api.here.com/6.2/geocode.json'
         );
         hereAdapter._reverseEndpoint.should.equal(
-          'https://reverse.geocoder.api.hereapi.com/6.2/reversegeocode.json'
+          'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json'
         );
       });
       


### PR DESCRIPTION
Fix HERE geocoder endpoints when using appId and appCode for authentication: The `ls` endpoint doesn't work for appCode authentication, and returns a 401: only the api / cit endpoints work.

~~Further, restore the use of the `production` option to choose production or CIT environment (only available for appCode authentication).~~

~~[More information](https://developer.here.com/documentation/geocoder/dev_guide/topics/request-constructing.html)~~