### PR TITLE
add opencage language feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,4 @@ var GeocoderFactory = require('./lib/geocoderfactory.js');
 
 var Exports = GeocoderFactory.getGeocoder.bind(GeocoderFactory);
 
-module.exports =  Exports;
+module.exports = Exports;

--- a/lib/geocoder/opencagegeocoder.js
+++ b/lib/geocoder/opencagegeocoder.js
@@ -48,8 +48,7 @@ OpenCageGeocoder.prototype._geocode = function (value, callback) {
     if (value.bounds) {
       if (Array.isArray(value.bounds)) {
         params.bounds = value.bounds.join(',');
-      }
-      else {
+      } else {
         params.bounds = value.bounds;
       }
     }
@@ -62,18 +61,18 @@ OpenCageGeocoder.prototype._geocode = function (value, callback) {
     if (value.minConfidence) {
       params.min_confidence = value.minConfidence;
     }
+    if (value.language) {
+      params.language = value.language;
+    }
     params.q = value.address;
-  }
-  else {
+  } else {
     params.q = value;
   }
 
   this.httpAdapter.get(this._endpoint, params, function (err, result) {
-
     if (err) {
       return callback(err);
     } else {
-
       var results = [];
 
       if (result && result.results instanceof Array) {
@@ -85,25 +84,23 @@ OpenCageGeocoder.prototype._geocode = function (value, callback) {
       results.raw = result;
       callback(false, results);
     }
-
   });
-
 };
 
 OpenCageGeocoder.prototype._formatResult = function (result) {
   var confidence = result.confidence || 0;
   return {
-    'latitude': result.geometry.lat,
-    'longitude': result.geometry.lng,
-    'country': result.components.country,
-    'city': result.components.city,
-    'state': result.components.state,
-    'zipcode': result.components.postcode,
-    'streetName': result.components.road,
-    'streetNumber': result.components.house_number,
-    'countryCode': result.components.country_code,
-    'county': result.components.county,
-    'extra': {
+    latitude: result.geometry.lat,
+    longitude: result.geometry.lng,
+    country: result.components.country,
+    city: result.components.city,
+    state: result.components.state,
+    zipcode: result.components.postcode,
+    streetName: result.components.road,
+    streetNumber: result.components.house_number,
+    countryCode: result.components.country_code,
+    county: result.components.county,
+    extra: {
       confidence: confidence,
       confidenceKM: this._ConfidenceInKM[result.confidence] || Number.NaN
     }


### PR DESCRIPTION
In this pull request, I added language param to opencage API as described in [opencage api](https://opencagedata.com/api#request) so it will attempt to return the response in the local language (ie. value we passed to language parameter during instantiating the geocoder object).

before making this PR I looked some part of the [code](https://github.com/nchaulet/node-geocoder/blob/51575ca573440f422944b8f0b307db749555be59/lib/geocoder/opencagegeocoder.js#L155), it looks like implement the language parameter but I don't know how to use it, so please review this PR. thanks