### PR TITLE
feat: mapbox geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ const geocoder = NodeGeocoder({
   - For `geocode` you can use simple `q` parameter or an object containing the different parameters defined here: http://locationiq.org/#docs
   - For `reverse`, you can pass over `{lat, lon}` and additional parameters defined in http://locationiq.org/#docs
   - No need to specify referer or email addresses, just locationiq api key, note that there are rate limits!
+- `mapbox` : MapBoxGeocoder. Supports address geocoding and reverse geocoding. Needs an apiKey
 - `mapquest` : MapQuestGeocoder. Supports address geocoding and reverse geocoding. Needs an apiKey
 - `nominatimmapquest`: Same geocoder as `openstreetmap`, but queries the MapQuest servers. You need to specify `options.apiKey`
 - `opencage`: OpenCage Geocoder. Aggregates many different open geocoder. Supports address and reverse geocoding with [many optional parameters](https://opencagedata.com/api#forward-opt). You need to specify `options.apiKey` which can be obtained at [OpenCage](https://opencagedata.com).

--- a/lib/geocoder/mapboxgeocoder.js
+++ b/lib/geocoder/mapboxgeocoder.js
@@ -1,0 +1,167 @@
+const AbstractGeocoder = require('./abstractgeocoder')
+
+/**
+ * available options 
+ * @see https://docs.mapbox.com/api/search/geocoding/
+ */
+const OPTIONS = [
+  'apiKey',
+  'language',
+  'country',
+  'autocomplete',
+  'bbox',
+  'fuzzyMatch',
+  'limit',
+  'proximity',
+  'routing'
+]
+
+const OPTIONS_MAP = {
+  apiKey: 'access_token'
+}
+
+/**
+ * Constructor
+ * @param <object> httpAdapter Http Adapter
+ * @param <object> options Options (apiKey, language, country, autocomplete, bbox, fuzzyMatch, limit, proximity, routing)
+ */
+class MapBoxGeocoder extends AbstractGeocoder {
+  constructor (httpAdapter, options) {
+    super(httpAdapter, options)
+    this.options = options || {}
+
+    // appId and appCode are deprecated
+    if (!this.options.apiKey) {
+      throw new Error('You must specify apiKey to use MapBox Geocoder')
+    }
+  }
+
+  /**
+   * Geocode
+   * @param <string>   value    Value to geocode (Address)
+   * @param <function> callback Callback method
+   */
+  _geocode (value, callback) {
+    let params = this._prepareQueryString({})
+    let searchtext = value
+
+    if (value.address) {
+      params = this._prepareQueryString(value)
+      searchtext = value.address
+    }
+
+    const endpoint = `${this._geocodeEndpoint}/${encodeURIComponent(searchtext)}.json`
+
+    this.httpAdapter.get(endpoint, params, (err, result) => {
+      let results = []
+      results.raw = result
+
+      if (err) {
+        return callback(err, results)
+      } else {
+        const view = result.features
+        if (!view) {
+          return callback(false, results)
+        }
+        results = view.map(this._formatResult)
+        results.raw = result
+
+        callback(false, results)
+      }
+    })
+  }
+
+  /**
+   * Reverse geocoding
+   * @param {lat:<number>,lon:<number>}  lat: Latitude, lon: Longitude
+   * @param <function> callback Callback method
+   */
+  _reverse (query, callback) {
+    const { lat, lon, ...other } = query
+
+    const params = this._prepareQueryString(other)
+    const endpoint = `${this._geocodeEndpoint}/${encodeURIComponent(`${lon},${lat}`)}.json`
+
+    this.httpAdapter.get(endpoint, params, (err, result) => {
+      let results = []
+      results.raw = result
+
+      if (err) {
+        return callback(err, results)
+      } else {
+        const view = result.features
+        if (!view) {
+          return callback(false, results)
+        }
+        results = view.map(this._formatResult)
+        results.raw = result
+
+        callback(false, results)
+      }
+    })
+  }
+
+  _formatResult (result) {
+    const context = (result.context || []).reduce((o, item) => {
+      // possible types: country, region, postcode, district, place, locality, neighborhood, address
+      const [type] = item.id.split('.')
+      if (type) {
+        o[type] = item.text
+        if (type === 'country' && item.short_code) {
+          o.countryCode = item.short_code.toUpperCase()
+        }
+      }
+      return o
+    }, {})
+    // get main type
+    const [type] = result.id.split('.')
+    if (type) {
+      context[type] = result.text
+    }
+
+    const properties = result.properties || {}
+
+    const extractedObj = {
+      latitude: result.center[1],
+      longitude: result.center[0],
+      formattedAddress: result.place_name,
+      country: context.country,
+      countryCode: context.countryCode,
+      state: context.region,
+      district: context.district,
+      city: context.place,
+      zipcode: context.postcode,
+      neighbourhood: context.neighborhood || context.locality,
+      extra: {
+        id: result.id,
+        address: properties.address || context.address,
+        category: properties.category,
+        bbox: result.bbox
+      }
+    }
+
+    return extractedObj
+  }
+
+  _prepareQueryString (params) {
+    OPTIONS.forEach((key) => {
+      const val = this.options[key]
+      if (val) {
+        const _key = OPTIONS_MAP[key] || key
+        params[_key] = val
+      }
+    })
+
+    return params
+  }
+}
+
+Object.defineProperties(MapBoxGeocoder.prototype, {
+  _geocodeEndpoint: {
+    get: function () {
+      return 'https://api.mapbox.com/geocoding/v5/mapbox.places'
+    }
+  }
+})
+
+module.exports = MapBoxGeocoder

--- a/lib/geocoderfactory.js
+++ b/lib/geocoderfactory.js
@@ -28,6 +28,7 @@ var VirtualEarthGeocoder = require('./geocoder/virtualearth.js');
 var SmartyStreets = require('./geocoder/smartystreetsgeocoder.js');
 var TeleportGeocoder = require('./geocoder/teleportgeocoder.js');
 var OpendataFranceGeocoder = require('./geocoder/opendatafrancegeocoder.js');
+var MapBoxGeocoder = require('./geocoder/mapboxgeocoder.js');
 
 /**
  * Geocoder Facotry
@@ -48,7 +49,6 @@ var GeocoderFactory = {
     if (adapterName === 'request') {
       return new RequestAdapter(null, options);
     }
-
     if (adapterName === 'fetch') {
       return new FetchAdapter(options);
     }
@@ -155,7 +155,9 @@ var GeocoderFactory = {
     if (geocoderName === 'opendatafrance') {
       return new OpendataFranceGeocoder(adapter);
     }
-
+    if (geocoderName === 'mapbox') {
+      return new MapBoxGeocoder(adapter, extra);
+    }
     throw new Error('No geocoder provider find for : ' + geocoderName);
   },
   /**

--- a/test/geocoder/mapboxgeocoder.test.js
+++ b/test/geocoder/mapboxgeocoder.test.js
@@ -1,0 +1,297 @@
+(function () {
+  const chai = require('chai')
+  const should = chai.should()
+  const expect = chai.expect
+  const sinon = require('sinon')
+
+  const MapBoxGeocoder = require('../../lib/geocoder/mapboxgeocoder.js')
+
+  const mockedHttpAdapter = {
+    get: function () { }
+  }
+
+  describe('MapBoxGeocoder', () => {
+    describe('#constructor', () => {
+      test('an http adapter must be set', () => {
+        expect(function () { new MapBoxGeocoder() }).to.throw(Error, 'MapBoxGeocoder need an httpAdapter')
+      })
+
+      test('Should be an instance of MapBoxGeocoder', () => {
+        const mapboxAdapter = new MapBoxGeocoder(mockedHttpAdapter, { apiKey: 'apiKey' })
+
+        mapboxAdapter.should.be.instanceof(MapBoxGeocoder)
+      })
+    })
+
+    describe('#geocode', () => {
+      test('Should not accept IPv4', () => {
+        const mapboxAdapter = new MapBoxGeocoder(mockedHttpAdapter, { apiKey: 'apiKey' })
+
+        expect(function () {
+          mapboxAdapter.geocode('127.0.0.1')
+        }).to.throw(Error, 'MapBoxGeocoder does not support geocoding IPv4')
+      })
+
+      test('Should not accept IPv6', () => {
+        const mapboxAdapter = new MapBoxGeocoder(mockedHttpAdapter, { apiKey: 'apiKey' })
+
+        expect(function () {
+          mapboxAdapter.geocode('2001:0db8:0000:85a3:0000:0000:ac1f:8001')
+        }).to.throw(Error, 'MapBoxGeocoder does not support geocoding IPv6')
+      })
+
+      test('Should call httpAdapter get method', () => {
+        const mock = sinon.mock(mockedHttpAdapter)
+        mock.expects('get').once().returns({ then: function () { } })
+
+        const mapboxAdapter = new MapBoxGeocoder(mockedHttpAdapter, { apiKey: 'apiKey' })
+
+        mapboxAdapter.geocode('1 champs élysée Paris')
+
+        mock.verify()
+      })
+
+      test('Should return geocoded address', done => {
+        const mock = sinon.mock(mockedHttpAdapter)
+        const resp = {
+          type: 'FeatureCollection',
+          query: [
+            '135',
+            'pilkington',
+            'avenue',
+            'birmingham'
+          ],
+          features: [
+            {
+              id: 'address.5430873521632660',
+              type: 'Feature',
+              place_type: [
+                'address'
+              ],
+              relevance: 0.805556,
+              properties: {
+                accuracy: 'point'
+              },
+              text_de: 'Pilkington Avenue',
+              place_name_de: '135 Pilkington Avenue, Sutton Coldfield, B72 1LH, Vereinigtes Königreich',
+              text: 'Pilkington Avenue',
+              place_name: '135 Pilkington Avenue, Sutton Coldfield, B72 1LH, Vereinigtes Königreich',
+              center: [
+                -1.816079,
+                52.54859
+              ],
+              geometry: {
+                type: 'Point',
+                coordinates: [
+                  -1.816079,
+                  52.54859
+                ]
+              },
+              address: '135',
+              context: [
+                {
+                  id: 'postcode.3341297116660100',
+                  text_de: 'B72 1LH',
+                  text: 'B72 1LH'
+                },
+                {
+                  id: 'place.9163981053829060',
+                  wikidata: 'Q868196',
+                  text_de: 'Sutton Coldfield',
+                  language_de: 'de',
+                  text: 'Sutton Coldfield',
+                  language: 'de'
+                },
+                {
+                  id: 'district.17727271997855680',
+                  wikidata: 'Q23124',
+                  text_de: 'West Midlands',
+                  language_de: 'de',
+                  text: 'West Midlands',
+                  language: 'de'
+                },
+                {
+                  id: 'region.13483278848453920',
+                  wikidata: 'Q21',
+                  short_code: 'GB-ENG',
+                  text_de: 'England',
+                  language_de: 'de',
+                  text: 'England',
+                  language: 'de'
+                },
+                {
+                  id: 'country.12405201072814600',
+                  wikidata: 'Q145',
+                  short_code: 'gb',
+                  text_de: 'Vereinigtes Königreich',
+                  language_de: 'de',
+                  text: 'Vereinigtes Königreich',
+                  language: 'de'
+                }
+              ]
+            }
+          ]
+        }
+        mock.expects('get').once().callsArgWith(2, false, resp)
+
+        const mapboxAdapter = new MapBoxGeocoder(mockedHttpAdapter, { apiKey: 'apiKey' })
+
+        mapboxAdapter.geocode('135 pilkington avenue, birmingham', function (err, results) {
+          mock.verify()
+
+          err.should.to.equal(false)
+
+          results[0].should.to.deep.equal({
+            latitude: 52.54859,
+            longitude: -1.816079,
+            formattedAddress: '135 Pilkington Avenue, Sutton Coldfield, B72 1LH, Vereinigtes Königreich',
+            country: 'Vereinigtes Königreich',
+            countryCode: 'GB',
+            state: 'England',
+            district: 'West Midlands',
+            city: 'Sutton Coldfield',
+            zipcode: 'B72 1LH',
+            neighbourhood: undefined,
+            extra: {
+              id: 'address.5430873521632660',
+              address: 'Pilkington Avenue',
+              category: undefined,
+              bbox: undefined
+            }
+          })
+
+          results.raw.should.deep.equal(resp)
+
+          mock.verify()
+          done()
+        })
+      })
+    })
+
+    describe('#reverse', () => {
+      test('Should return geocoded address', done => {
+        const mock = sinon.mock(mockedHttpAdapter)
+        const resp = {
+          type: 'FeatureCollection',
+          query: [
+            -73.9612889,
+            40.714232
+          ],
+          features: [
+            {
+              id: 'address.3679793406555678',
+              type: 'Feature',
+              place_type: [
+                'address'
+              ],
+              relevance: 1,
+              properties: {
+                accuracy: 'parcel'
+              },
+              text_de: 'Bedford Avenue',
+              place_name_de: '277 Bedford Avenue, Brooklyn, New York 11211, Vereinigte Staaten',
+              text: 'Bedford Avenue',
+              place_name: '277 Bedford Avenue, Brooklyn, New York 11211, Vereinigte Staaten',
+              center: [
+                -73.961297,
+                40.714259
+              ],
+              geometry: {
+                type: 'Point',
+                coordinates: [
+                  -73.961297,
+                  40.714259
+                ]
+              },
+              address: '277',
+              context: [
+                {
+                  id: 'neighborhood.2102030',
+                  text_de: 'Williamsburg',
+                  text: 'Williamsburg'
+                },
+                {
+                  id: 'postcode.10441086852103120',
+                  text_de: '11211',
+                  text: '11211'
+                },
+                {
+                  id: 'locality.6335122455180360',
+                  wikidata: 'Q18419',
+                  text_de: 'Brooklyn',
+                  language_de: 'de',
+                  text: 'Brooklyn',
+                  language: 'de'
+                },
+                {
+                  id: 'place.2618194975964500',
+                  wikidata: 'Q60',
+                  text_de: 'New York City',
+                  language_de: 'de',
+                  text: 'New York City',
+                  language: 'de'
+                },
+                {
+                  id: 'district.3780609411998600',
+                  wikidata: 'Q11980692',
+                  text_de: 'Kings County',
+                  language_de: 'en',
+                  text: 'Kings County',
+                  language: 'en'
+                },
+                {
+                  id: 'region.17349986251855570',
+                  wikidata: 'Q1384',
+                  short_code: 'US-NY',
+                  text_de: 'New York',
+                  language_de: 'de',
+                  text: 'New York',
+                  language: 'de'
+                },
+                {
+                  id: 'country.19678805456372290',
+                  wikidata: 'Q30',
+                  short_code: 'us',
+                  text_de: 'Vereinigte Staaten',
+                  language_de: 'de',
+                  text: 'Vereinigte Staaten',
+                  language: 'de'
+                }
+              ]
+            }
+          ]
+        }
+
+        mock.expects('get').once().callsArgWith(2, false, resp)
+
+        const mapboxAdapter = new MapBoxGeocoder(mockedHttpAdapter, { apiKey: 'api' })
+
+        mapboxAdapter.reverse({ lat: 40.714232, lon: -73.9612889 }, function (err, results) {
+          err.should.to.equal(false)
+          results[0].should.to.deep.equal({
+            latitude: 40.714259,
+            longitude: -73.961297,
+            formattedAddress: '277 Bedford Avenue, Brooklyn, New York 11211, Vereinigte Staaten',
+            country: 'Vereinigte Staaten',
+            countryCode: 'US',
+            state: 'New York',
+            district: 'Kings County',
+            city: 'New York City',
+            zipcode: '11211',
+            neighbourhood: 'Williamsburg',
+            extra: {
+              id: 'address.3679793406555678',
+              address: 'Bedford Avenue',
+              category: undefined,
+              bbox: undefined
+            }
+          })
+          results.raw.should.deep.equal(resp)
+
+          mock.verify()
+          done()
+        })
+      })
+    })
+  })
+})()


### PR DESCRIPTION
Implements a mapbox geocoder with forward and reverse search. 
See https://docs.mapbox.com/api/search/geocoding/

Assigned feature-request #287