### PR TITLE
Fixing "non-UTF-8 string" issue with Google

### DIFF
--- a/lib/geocoder/googlegeocoder.js
+++ b/lib/geocoder/googlegeocoder.js
@@ -306,7 +306,7 @@ GoogleGeocoder.prototype._reverse = function (query, callback) {
 
 GoogleGeocoder.prototype._encodeSpecialChars = function(value) {
   if (typeof value === 'string') {
-    return value.replace(/\u001a/g, ' ');
+    return encodeURIComponent(escape(value.replace(/\u001a/g, ' '));
   }
 
   return value;


### PR DESCRIPTION
I had some issues with "non-UTF-8 string" in the address parameter and Google returned `One of the input parameters contains a non-UTF-8 string`.