### PR TITLE
Support country for TomTom geocoding

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 9,
   "node": true,
   "globals": {"describe" : true, "it" : true}
 }

--- a/lib/geocoder/heregeocoder.js
+++ b/lib/geocoder/heregeocoder.js
@@ -1,4 +1,5 @@
 const AbstractGeocoder = require('./abstractgeocoder');
+const ValueError = require('./../error/valueerror');
 
 const OPTIONS = [
   'apiKey',
@@ -71,6 +72,9 @@ class HereGeocoder extends AbstractGeocoder {
       if (err) {
         return callback(err, results);
       } else {
+        if (result.type === 'ApplicationError') {
+          return callback(new ValueError(result.Details), results);
+        }
         var view = result.Response.View[0];
         if (!view) {
           return callback(false, results);

--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var AbstractGeocoder = require('./abstractgeocoder');
+var countries = require('i18n-iso-countries');
 
 /**
  * Constructor
@@ -37,7 +38,30 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
     params.language = this.options.language;
   }
 
-  var url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
+  var address = value;
+  var url;
+  if (typeof value === 'object') {
+    if (!value.address) {
+      return callback(new Error('You must specify a valid address.'));
+    }
+
+    address = value.address.toString()
+    if (address === '') {
+      return callback(new Error('You must specify a valid address.'));
+    }
+
+    if (value.country) {
+      const country = value.country.toString()
+      if (typeof country !== 'string' || !countries.isValid(country)) {
+        return callback(new Error('Provided country is not valid.'));
+      }
+
+      params.country = value.country;
+    }
+  }
+
+  url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
+
 
   this.httpAdapter.get(url, params, function(err, result) {
     if (err) {

--- a/lib/httpadapter/fetchadapter.js
+++ b/lib/httpadapter/fetchadapter.js
@@ -39,11 +39,19 @@ class FetchAdapter {
           url + '?' + querystring.encode(params),
           options
         );
-
+        const contentType = res.headers.get('content-type');
+        if (!contentType || contentType.indexOf('application/json') === -1) {
+          throw new HttpError(await res.text(), {
+            code: res.statusCode
+          });
+        }
         return res.json();
       })
       .catch(function(error) {
-        var _error = error.cause ? error.cause : error;
+        if (error instanceof HttpError) {
+          throw error;
+        }
+        const _error = error.cause ? error.cause : error;
         throw new HttpError(_error.message, {
           code: _error.code
         });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.2",
+    "i18n-iso-countries": "^7.2.0",
     "node-fetch": "^2.6.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.2"


### PR DESCRIPTION
Forward geocoding for TomTom only supports the address. This fix adds support for sending an address (as string) or an object of parameters (only `country` for now).