### PR TITLE
Standardize batch output

### DIFF
--- a/integration_test/geocoder/tomtomgeocoder.test.js
+++ b/integration_test/geocoder/tomtomgeocoder.test.js
@@ -41,8 +41,8 @@ describe('Mapbox geocoder', () => {
       ]);
 
       expect(res[0]).toBeDefined();
-      expect(res[0].values[0]).toBeDefined();
-      expect(res[0].values[0]).toMatchObject({
+      expect(res[0].value[0]).toBeDefined();
+      expect(res[0].value[0]).toMatchObject({
         latitude: 45.52106,
         longitude: -73.61073,
         country: 'Canada',
@@ -52,8 +52,8 @@ describe('Mapbox geocoder', () => {
       });
 
       expect(res[1]).toBeDefined();
-      expect(res[1].values[0]).toBeDefined();
-      expect(res[1].values[0]).toMatchObject({
+      expect(res[1].value[0]).toBeDefined();
+      expect(res[1].value[0]).toMatchObject({
         latitude: 45.53383,
         longitude: -73.58328,
         country: 'Canada',

--- a/lib/geocoder/abstractgeocoder.js
+++ b/lib/geocoder/abstractgeocoder.js
@@ -107,8 +107,11 @@ AbstractGeocoder.prototype.geocode = function(value, callback) {
     Promise.all(
       values.map(value => 
         new Promise(resolve => {
-          this.geocode(value, (error, data) => {
-            resolve({ error, data });
+          this.geocode(value, (error, value) => {
+            resolve({
+              error,
+              value
+            });
           });
         })
       )

--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -197,12 +197,12 @@ TomTomGeocoder.prototype.__parseBatchResults = function (rawResults) {
     if (result.statusCode !== 200) {
       return {
         error: `statusCode: ${result.statusCode}`,
-        values: []
+        value: []
       };
     }
     return {
       error: null,
-      values: result.response.results.map(this._formatResult)
+      value: result.response.results.map(this._formatResult)
     };
   });
 };

--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -202,7 +202,10 @@ TomTomGeocoder.prototype.__parseBatchResults = function (rawResults) {
     }
     return {
       error: null,
-      value: result.response.results.map(this._formatResult)
+      value: result.response.results.map((value) => ({
+        ...this._formatResult(value),
+        provider: 'tomtom'
+      }))
     };
   });
 };


### PR DESCRIPTION
Standardize batch output:

```json
[
    {
        "error": null,
        "value": [
            {
               // ... geocoding intem
            }
        ]
    },
    {
        "error": "...",
        "value": []
    }
]
```

Note: I would say that `values` it's more semantically accurate but since it was already `value` let's keep that way for compatibility. Sorry I had introduced this bug 😞 