### PR TITLE
Propagate country param to TomTom geocoder

### DIFF
--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -37,6 +37,10 @@ TomTomGeocoder.prototype._geocode = function (value, callback) {
     params.language = this.options.language;
   }
 
+  if (this.options.country) {
+    params.countrySet = this.options.country;
+  }
+
   var url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
 
   this.httpAdapter.get(url, params, function (err, result) {


### PR DESCRIPTION
## What does this PR do?

- If `country` was passed as an option when instantiating the geocoder, it will be propagated to the TomTom API as the `countrySet` argument.

## Decisions taken

- The TomTom API `countrySet` parameter really accepts a comma-separated list of Alpha2 coudes (`ES,AU,US`), but for simplicity and to avoid maintaining redundant validations (the TomTom API will already be validating the format of this) we decided just to propagate the value as it is received.