### PR TITLE
Changes to LocationIQ API URLs

### DIFF
--- a/lib/geocoder/locationiqgeocoder.js
+++ b/lib/geocoder/locationiqgeocoder.js
@@ -25,8 +25,7 @@ var LocationIQGeocoder = function LocationIQGeocoder(httpAdapter, apiKey) {
 
 util.inherits(LocationIQGeocoder, AbstractGeocoder);
 
-LocationIQGeocoder.prototype._endpoint = 'http://locationiq.org/v1';
-LocationIQGeocoder.prototype._endpoint_reverse = 'http://osm1.unwiredlabs.com/locationiq/v1/reverse.php';
+LocationIQGeocoder.prototype._endpoint = 'http://us1.locationiq.com/v1';
 
 /**
  * Geocode
@@ -60,7 +59,7 @@ LocationIQGeocoder.prototype._geocode = function(value, callback) {
   }
   this._forceParams(params);
 
-  this.httpAdapter.get(this._endpoint + '/search.php', params,
+  this.httpAdapter.get(this._endpoint + '/search', params,
     function(err, responseData) {
       if (err) {
         return callback(err);
@@ -96,7 +95,7 @@ LocationIQGeocoder.prototype._reverse = function(query, callback) {
   }
   this._forceParams(params);
 
-  this.httpAdapter.get(this._endpoint_reverse, params,
+  this.httpAdapter.get(this._endpoint + '/reverse', params,
     function(err, responseData) {
       if (err) {
         return callback(err);

--- a/test/geocoder/locationiqgeocoder.test.js
+++ b/test/geocoder/locationiqgeocoder.test.js
@@ -17,7 +17,7 @@
       test('an http adapter must be set', () => {
         expect(function() {
           new LocationIQGeocoder();
-        }).to.throw(Error, 'ocationIQGeocoder need an httpAdapter');
+        }).to.throw(Error, 'LocationIQGeocoder need an httpAdapter');
       });
 
       test('must have an api key as second argument', () => {
@@ -189,7 +189,7 @@
       test('should ignore "format" and "addressdetails" arguments', done => {
         var mock = sinon.mock(mockedHttpAdapter);
         mock.expects('get').once().callsArgWith(2, false, [])
-          .withArgs('http://locationiq.org/v1/search.php', {
+          .withArgs('http://us1.locationiq.com/v1/search', {
             addressdetails: '1',
             format: 'json',
             key: 'API_KEY',
@@ -213,7 +213,7 @@
       test('Should correctly set extra arguments', done => {
         var mock = sinon.mock(mockedHttpAdapter);
         mock.expects('get').once().callsArgWith(2, false, [])
-          .withArgs('http://osm1.unwiredlabs.com/locationiq/v1/reverse.php', {
+          .withArgs('http://us1.locationiq.com/v1/reverse', {
             addressdetails: '1',
             format: 'json',
             key: 'API_KEY',
@@ -237,7 +237,7 @@
       test('should ignore "format" and "addressdetails" arguments', done => {
         var mock = sinon.mock(mockedHttpAdapter);
         mock.expects('get').once().callsArgWith(2, false, [])
-          .withArgs('http://osm1.unwiredlabs.com/locationiq/v1/reverse.php', {
+          .withArgs('http://us1.locationiq.com/v1/reverse', {
             addressdetails: '1',
             format: 'json',
             key: 'API_KEY',


### PR DESCRIPTION
Support to endpoint http://locationiq.org & http://locationiq.com has been deprecated. Changed URLs & tests to reflect the documented endpoints