### PR TITLE
fix: body used already error fix #340

### DIFF
--- a/lib/httpadapter/fetchadapter.js
+++ b/lib/httpadapter/fetchadapter.js
@@ -42,7 +42,7 @@ class FetchAdapter {
         if (fullResponse) {
           return res;
         }
-        const rawResponseBody = res.text();
+        const rawResponseBody = await res.text();
         try {
           return JSON.parse(rawResponseBody);
         } catch (e) {

--- a/lib/httpadapter/fetchadapter.js
+++ b/lib/httpadapter/fetchadapter.js
@@ -42,10 +42,11 @@ class FetchAdapter {
         if (fullResponse) {
           return res;
         }
+        const rawResponseBody = res.text();
         try {
-          return await res.json();
+          return JSON.parse(rawResponseBody);
         } catch (e) {
-          throw new HttpError(await res.text(), {
+          throw new HttpError(rawResponseBody, {
             code: res.statusCode
           });
         }


### PR DESCRIPTION
Fix "body used already for" error message as json and text is called. Should fix https://github.com/nchaulet/node-geocoder/issues/340