### PR TITLE
Handling undefined values

### DIFF
--- a/lib/geocoder/heregeocoder.js
+++ b/lib/geocoder/heregeocoder.js
@@ -78,7 +78,7 @@ class HereGeocoder extends AbstractGeocoder {
         if (result.error === 'Unauthorized') {
           return callback(new ValueError(result.error_description), results);
         }
-        var view = result.Response.View[0];
+        var view = result.Response?.View[0];
         if (!view) {
           return callback(false, results);
         }


### PR DESCRIPTION

Passing "united states" as a attribute for the geocoder, like
    const data: any = await geocoder.geocode(location);

but getting Error:

return target.apply(this, arguments);
                      ^
TypeError: Cannot read properties of undefined (reading 'View')
    at /home/aximsoft/Project/secuvy/api/command-center/node_modules/node-geocoder/lib/geocoder/heregeocoder.js:81:36
    at tryCatcher (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/util.js:16:23)
    at Promise.successAdapter [as _fulfillmentHandler0] (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/nodeify.js:23:30)
    at Promise._settlePromise (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/promise.js:601:21)
    at Promise._settlePromise0 (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/promise.js:729:18)
    at _drainQueueStep (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues (/home/aximsoft/Project/secuvy/api/command-center/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (node:internal/timers:478:21)
    at process.topLevelDomainCallback (node:domain:160:15)
    at process.callbackTrampoline (node:internal/async_hooks:128:24)