### PR TITLE
[Fix] Cannot read properties of undefined (reading 'country_code')

### DIFF
--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -87,14 +87,14 @@ OpenStreetMapGeocoder.prototype._formatResult = function(result) {
         'latitude' : latitude,
         'longitude' : longitude,
         'formattedAddress': result.display_name,
-        'country' : result.address.country,
-        'city' : result.address.city || result.address.town || result.address.village || result.address.hamlet,
-        'state': result.address.state,
-        'zipcode' : result.address.postcode,
-        'streetName': result.address.road || result.address.cycleway,
-        'streetNumber' : result.address.house_number,
+        'country' : result.address?.country,
+        'city' : result.address?.city || result.address?.town || result.address?.village || result.address?.hamlet,
+        'state': result.address?.state,
+        'zipcode' : result.address?.postcode,
+        'streetName': result.address?.road || result.address?.cycleway,
+        'streetNumber' : result.address?.house_number,
         'countryCode' : countryCode,
-        'neighbourhood': result.address.neighbourhood || ''
+        'neighbourhood': result.address?.neighbourhood || ''
     };
 };
 

--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -67,34 +67,35 @@ OpenStreetMapGeocoder.prototype._geocode = function(value, callback) {
 };
 
 OpenStreetMapGeocoder.prototype._formatResult = function(result) {
+    var countryCode, latitude, longitude, formattedAddress, country, city, state, zipcode, streetName, streetNumber, neighbourhood;
 
-    var countryCode = result.address == null ? undefined : result.country_code;
-    if (countryCode) {
-        countryCode = countryCode.toUpperCase();
+    if (result.address) {
+        countryCode = result.address.country_code ? result.address.country_code.toUpperCase() : undefined;
+        country = result.address.country;
+        city = result.address.city || result.address.town || result.address.village || result.address.hamlet;
+        state = result.address.state;
+        zipcode = result.address.postcode;
+        streetName = result.address.road || result.address.cycleway;
+        streetNumber = result.address.house_number;
+        neighbourhood = result.address.neighbourhood || '';
     }
 
-    var latitude = result.lat;
-    if (latitude) {
-      latitude = parseFloat(latitude);
-    }
-
-    var longitude = result.lon;
-    if (longitude) {
-      longitude = parseFloat(longitude);
-    }
+    latitude = result.lat ? parseFloat(result.lat) : undefined;
+    longitude = result.lon ? parseFloat(result.lon) : undefined;
+    formattedAddress = result.display_name;
 
     return {
-        'latitude' : latitude,
-        'longitude' : longitude,
-        'formattedAddress': result.display_name,
-        'country' : result.address == null ? undefined : result.address.country,
-        'city' : result.address == null ? undefined : result.address.city || result.address.town || result.address.village || result.address.hamlet,
-        'state': result.address == null ? undefined : result.address.state,
-        'zipcode' : result.address == null ? undefined : result.address.postcode,
-        'streetName': result.address == null ? undefined : result.address.road || result.address.cycleway,
-        'streetNumber' : result.address == null ? undefined : result.address.house_number,
-        'countryCode' : countryCode,
-        'neighbourhood': result.address == null ? '' : result.address.neighbourhood || ''
+        'latitude': latitude,
+        'longitude': longitude,
+        'formattedAddress': formattedAddress,
+        'country': country,
+        'city': city,
+        'state': state,
+        'zipcode': zipcode,
+        'streetName': streetName,
+        'streetNumber': streetNumber,
+        'countryCode': countryCode,
+        'neighbourhood': neighbourhood
     };
 };
 

--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -68,7 +68,7 @@ OpenStreetMapGeocoder.prototype._geocode = function(value, callback) {
 
 OpenStreetMapGeocoder.prototype._formatResult = function(result) {
 
-    var countryCode = result.address?.country_code;
+    var countryCode = result.address == null ? undefined : result.country_code;
     if (countryCode) {
         countryCode = countryCode.toUpperCase();
     }
@@ -87,14 +87,14 @@ OpenStreetMapGeocoder.prototype._formatResult = function(result) {
         'latitude' : latitude,
         'longitude' : longitude,
         'formattedAddress': result.display_name,
-        'country' : result.address?.country,
-        'city' : result.address?.city || result.address?.town || result.address?.village || result.address?.hamlet,
-        'state': result.address?.state,
-        'zipcode' : result.address?.postcode,
-        'streetName': result.address?.road || result.address?.cycleway,
-        'streetNumber' : result.address?.house_number,
+        'country' : result.address == null ? undefined : result.address.country,
+        'city' : result.address == null ? undefined : result.address.city || result.address.town || result.address.village || result.address.hamlet,
+        'state': result.address == null ? undefined : result.address.state,
+        'zipcode' : result.address == null ? undefined : result.address.postcode,
+        'streetName': result.address == null ? undefined : result.address.road || result.address.cycleway,
+        'streetNumber' : result.address == null ? undefined : result.address.house_number,
         'countryCode' : countryCode,
-        'neighbourhood': result.address?.neighbourhood || ''
+        'neighbourhood': result.address == null ? '' : result.address.neighbourhood || ''
     };
 };
 

--- a/lib/geocoder/openstreetmapgeocoder.js
+++ b/lib/geocoder/openstreetmapgeocoder.js
@@ -68,7 +68,7 @@ OpenStreetMapGeocoder.prototype._geocode = function(value, callback) {
 
 OpenStreetMapGeocoder.prototype._formatResult = function(result) {
 
-    var countryCode = result.address.country_code;
+    var countryCode = result.address?.country_code;
     if (countryCode) {
         countryCode = countryCode.toUpperCase();
     }


### PR DESCRIPTION
Fixes https://github.com/nchaulet/node-geocoder/issues/350.

I would really appreciate if this could be merged in the near future, as it's affecting the uptime of my app.

Usage (the try/catch doesn't help):
```
  await geocoder
    .geocode(privateListingRes.address)
    .then((entries) => {
      const entry = entries[0];
      if (entry?.latitude && entry.longitude) {
        latitude = entry.latitude;
        longitude = entry.longitude;
      }
    })
    .catch(() => undefined);
```

Error: 
```
TypeError: Cannot read properties of undefined (reading 'country_code')
    at OpenStreetMapGeocoder._formatResult (/home/ec2-user/superset/node_modules/.pnpm/node-geocoder@4.2.0/node_modules/node-geocoder/lib/geocoder/openstreetmapgeocoder.js:71:38)
    at /home/ec2-user/superset/node_modules/.pnpm/node-geocoder@4.2.0/node_modules/node-geocoder/lib/geocoder/openstreetmapgeocoder.js:58:34
    at tryCatcher (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/util.js:16:23)
    at Promise.successAdapter [as _fulfillmentHandler0] (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/nodeify.js:23:30)
    at Promise._settlePromise (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/promise.js:601:21)
    at Promise._settlePromise0 (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/promise.js:729:18)
    at _drainQueueStep (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues (/home/ec2-user/superset/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (node:internal/timers:466:21)
````